### PR TITLE
Add MVP dashboard with contextual AI chat

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { DashboardSidebar } from "@/components/dashboard/dashboard-sidebar";
+import { DashboardContent } from "@/components/dashboard/dashboard-content";
+import type { TabKey } from "@/components/dashboard/dashboard-nav-tabs";
+
+export default function DashboardPage() {
+  const [activeSubPage, setActiveSubPage] = useState("");
+  const [activeTab, setActiveTab] = useState<TabKey>("do");
+
+  const handleSubPageChange = (key: string) => {
+    setActiveSubPage(key);
+    setActiveTab("do");
+  };
+
+  return (
+    <SidebarProvider>
+      <DashboardSidebar
+        activeSubPage={activeSubPage}
+        onSubPageChange={handleSubPageChange}
+      />
+      <DashboardContent
+        activeSubPage={activeSubPage}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+      />
+    </SidebarProvider>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -157,6 +157,18 @@
   }
 }
 
+/* Dark sidebar theme */
+.sidebar-dark {
+  --sidebar: #0c1e3d;
+  --sidebar-foreground: #e2e8f0;
+  --sidebar-primary: #ff6b35;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: rgba(255, 255, 255, 0.1);
+  --sidebar-accent-foreground: #ffffff;
+  --sidebar-border: rgba(255, 255, 255, 0.1);
+  --sidebar-ring: rgba(255, 255, 255, 0.2);
+}
+
 /* Custom prose styling for markdown */
 .prose-ascenta {
   --tw-prose-body: #0c1e3d;

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { ChatMessage } from "@/components/chat/chat-message";
+import { ChatInput } from "@/components/chat/chat-input";
+import { extractLastWorkflowRunId } from "@/components/chat/workflow-blocks";
+import { AI_CONFIG } from "@/lib/ai/config";
+
+interface Message {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+}
+
+const DEFAULT_MODEL = AI_CONFIG.defaultModels.anthropic;
+
+interface PageConfig {
+  title: string;
+  description: string;
+  suggestions: { title: string; prompt: string }[];
+}
+
+const PAGE_CONFIG: Record<string, PageConfig> = {
+  "launch/onboarding": {
+    title: "Onboarding",
+    description: "Set up new hires for success with structured onboarding workflows.",
+    suggestions: [
+      { title: "Create onboarding plan", prompt: "Help me create an onboarding plan for a new employee" },
+      { title: "First-day checklist", prompt: "Generate a first-day checklist for a new hire" },
+      { title: "30-60-90 day plan", prompt: "Draft a 30-60-90 day onboarding plan" },
+      { title: "Welcome email", prompt: "Write a welcome email for a new team member" },
+    ],
+  },
+  "launch/training": {
+    title: "Training Plans",
+    description: "Build and manage training programs for employee development.",
+    suggestions: [
+      { title: "Training curriculum", prompt: "Help me design a training curriculum for a new role" },
+      { title: "Skills assessment", prompt: "Create a skills gap assessment template" },
+      { title: "Learning objectives", prompt: "Draft learning objectives for a training program" },
+      { title: "Training schedule", prompt: "Build a training schedule for the first quarter" },
+    ],
+  },
+  "launch/probation": {
+    title: "Probation Review",
+    description: "Manage probationary periods with structured reviews and documentation.",
+    suggestions: [
+      { title: "Probation review", prompt: "Help me write a probation period review" },
+      { title: "Performance criteria", prompt: "Define probation performance criteria for a role" },
+      { title: "Extension notice", prompt: "Draft a probation extension notice" },
+      { title: "Confirmation letter", prompt: "Write a probation confirmation letter" },
+    ],
+  },
+  "protect/warnings": {
+    title: "Written Warnings",
+    description: "Issue and manage written warnings with proper documentation and compliance.",
+    suggestions: [
+      { title: "Draft a written warning", prompt: "Help me write a corrective action for an employee" },
+      { title: "Attendance warning", prompt: "Draft a written warning for attendance issues" },
+      { title: "Conduct warning", prompt: "Write a written warning for a code of conduct violation" },
+      { title: "Final warning", prompt: "Draft a final written warning before termination" },
+    ],
+  },
+  "protect/pip": {
+    title: "PIP Management",
+    description: "Create and manage Performance Improvement Plans with clear goals and timelines.",
+    suggestions: [
+      { title: "Create a PIP", prompt: "Draft a Performance Improvement Plan for an underperforming employee" },
+      { title: "PIP progress review", prompt: "Help me write a PIP mid-point progress review" },
+      { title: "PIP completion", prompt: "Draft a PIP completion assessment" },
+      { title: "PIP goals", prompt: "Help me define measurable PIP goals and milestones" },
+    ],
+  },
+  "protect/compliance": {
+    title: "Compliance",
+    description: "Ensure HR processes meet legal and regulatory requirements.",
+    suggestions: [
+      { title: "Policy audit", prompt: "Help me audit our HR policies for compliance gaps" },
+      { title: "Documentation review", prompt: "Review our employee documentation for compliance issues" },
+      { title: "Regulatory update", prompt: "What recent labor law changes should I be aware of?" },
+      { title: "Accommodation request", prompt: "Guide me through processing an ADA accommodation request" },
+    ],
+  },
+  "attract/recruitment": {
+    title: "Recruitment",
+    description: "Streamline hiring with job postings, screening, and offer management.",
+    suggestions: [
+      { title: "Job description", prompt: "Help me write a job description for a new role" },
+      { title: "Interview questions", prompt: "Generate structured interview questions for a role" },
+      { title: "Offer letter", prompt: "Draft an offer letter for a new hire" },
+      { title: "Candidate scorecard", prompt: "Create a candidate evaluation scorecard" },
+    ],
+  },
+  "attract/engagement": {
+    title: "Engagement",
+    description: "Boost employee satisfaction, retention, and workplace culture.",
+    suggestions: [
+      { title: "Engagement survey", prompt: "Help me design an employee engagement survey" },
+      { title: "Stay interview", prompt: "Draft stay interview questions for key employees" },
+      { title: "Action plan", prompt: "Create an action plan from engagement survey results" },
+      { title: "Recognition program", prompt: "Help me design an employee recognition program" },
+    ],
+  },
+  "attract/recognition": {
+    title: "Recognition",
+    description: "Celebrate achievements and build a culture of appreciation.",
+    suggestions: [
+      { title: "Award nomination", prompt: "Help me write an employee award nomination" },
+      { title: "Milestone celebration", prompt: "Plan a work anniversary milestone celebration" },
+      { title: "Team shoutout", prompt: "Write a team recognition announcement for a project win" },
+      { title: "Peer recognition", prompt: "Design a peer-to-peer recognition program" },
+    ],
+  },
+};
+
+const DEFAULT_CONFIG: PageConfig = {
+  title: "Ascenta",
+  description: "Your AI-powered HR assistant.",
+  suggestions: [
+    { title: "Written warning", prompt: "Help me write a corrective action for an employee" },
+    { title: "Performance plan", prompt: "Draft a PIP for an underperforming employee" },
+    { title: "Policy question", prompt: "What is our policy on remote work?" },
+    { title: "Employee lookup", prompt: "Look up information about an employee" },
+  ],
+};
+
+interface ChatPanelProps {
+  subPage: string;
+}
+
+export function ChatPanel({ subPage }: ChatPanelProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [conversationId, setConversationId] = useState<string | undefined>();
+  const [model, setModel] = useState<string>(DEFAULT_MODEL);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const config = PAGE_CONFIG[subPage] ?? DEFAULT_CONFIG;
+
+  // Reset conversation when sub-page changes
+  const resetChat = useCallback(() => {
+    abortControllerRef.current?.abort();
+    setMessages([]);
+    setInput("");
+    setConversationId(undefined);
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    resetChat();
+  }, [subPage, resetChat]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const handleSubmit = async (overrideValue?: string) => {
+    const content = (overrideValue ?? input).trim();
+    if (!content || isLoading) return;
+
+    const userMessage: Message = {
+      id: `user-${Date.now()}`,
+      role: "user",
+      content,
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    if (!overrideValue) setInput("");
+    setIsLoading(true);
+
+    const assistantMessageId = `assistant-${Date.now()}`;
+    setMessages((prev) => [
+      ...prev,
+      { id: assistantMessageId, role: "assistant", content: "" },
+    ]);
+
+    try {
+      abortControllerRef.current = new AbortController();
+
+      const lastAssistant = [...messages].reverse().find((m) => m.role === "assistant");
+      const activeWorkflowRunId = lastAssistant
+        ? extractLastWorkflowRunId(lastAssistant.content)
+        : undefined;
+
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ role: "user", content }],
+          conversationId,
+          userId: "anonymous",
+          model,
+          ...(activeWorkflowRunId ? { activeWorkflowRunId } : {}),
+        }),
+        signal: abortControllerRef.current.signal,
+      });
+
+      const newConversationId = res.headers.get("X-Conversation-Id");
+      if (newConversationId && !conversationId) {
+        setConversationId(newConversationId);
+      }
+
+      if (!res.ok) throw new Error("Failed to get response");
+
+      const reader = res.body?.getReader();
+      const decoder = new TextDecoder();
+
+      if (reader) {
+        let fullContent = "";
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          fullContent += decoder.decode(value, { stream: true });
+          setMessages((prev) =>
+            prev.map((msg) =>
+              msg.id === assistantMessageId ? { ...msg, content: fullContent } : msg
+            )
+          );
+        }
+      }
+    } catch (error) {
+      if ((error as Error).name === "AbortError") {
+        // Request was cancelled
+      } else {
+        console.error("Chat error:", error);
+        setMessages((prev) =>
+          prev.map((msg) =>
+            msg.id === assistantMessageId
+              ? { ...msg, content: "Sorry, I encountered an error. Please try again." }
+              : msg
+          )
+        );
+      }
+    } finally {
+      setIsLoading(false);
+      abortControllerRef.current = null;
+    }
+  };
+
+  const handleStop = () => {
+    abortControllerRef.current?.abort();
+    setIsLoading(false);
+  };
+
+  const handleWorkflowFieldSelect = async (runId: string, fieldKey: string, value: string) => {
+    if (isLoading || !conversationId) return;
+    setIsLoading(true);
+    const assistantMessageId = `assistant-${Date.now()}`;
+    setMessages((prev) => [...prev, { id: assistantMessageId, role: "assistant", content: "" }]);
+    try {
+      abortControllerRef.current = new AbortController();
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          conversationId,
+          model,
+          workflowFieldSelection: { runId, fieldKey, value },
+        }),
+        signal: abortControllerRef.current.signal,
+      });
+      const newConversationId = res.headers.get("X-Conversation-Id");
+      if (newConversationId && !conversationId) {
+        setConversationId(newConversationId);
+      }
+      if (!res.ok) throw new Error("Failed to get response");
+      const reader = res.body?.getReader();
+      const decoder = new TextDecoder();
+      let fullContent = "";
+      if (reader) {
+        while (true) {
+          const { done, value: chunk } = await reader.read();
+          if (done) break;
+          fullContent += decoder.decode(chunk, { stream: true });
+          setMessages((prev) =>
+            prev.map((msg) =>
+              msg.id === assistantMessageId ? { ...msg, content: fullContent } : msg
+            )
+          );
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name !== "AbortError") {
+        console.error("Chat error:", err);
+        setMessages((prev) =>
+          prev.map((msg) =>
+            msg.id === assistantMessageId
+              ? { ...msg, content: "Sorry, something went wrong. Please try again." }
+              : msg
+          )
+        );
+      }
+    } finally {
+      setIsLoading(false);
+      abortControllerRef.current = null;
+    }
+  };
+
+  const handleWorkflowFollowUpSelect = async (runId: string, type: "email" | "script") => {
+    if (isLoading || !conversationId) return;
+    setIsLoading(true);
+    const assistantMessageId = `assistant-${Date.now()}`;
+    setMessages((prev) => [...prev, { id: assistantMessageId, role: "assistant", content: "" }]);
+    try {
+      abortControllerRef.current = new AbortController();
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          conversationId,
+          model,
+          workflowFollowUp: { runId, type },
+        }),
+        signal: abortControllerRef.current.signal,
+      });
+      if (!res.ok) throw new Error("Failed to get response");
+      const reader = res.body?.getReader();
+      const decoder = new TextDecoder();
+      let fullContent = "";
+      if (reader) {
+        while (true) {
+          const { done, value: chunk } = await reader.read();
+          if (done) break;
+          fullContent += decoder.decode(chunk, { stream: true });
+          setMessages((prev) =>
+            prev.map((msg) =>
+              msg.id === assistantMessageId ? { ...msg, content: fullContent } : msg
+            )
+          );
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name !== "AbortError") {
+        console.error("Chat error:", err);
+        setMessages((prev) =>
+          prev.map((msg) =>
+            msg.id === assistantMessageId
+              ? { ...msg, content: "Sorry, something went wrong. Please try again." }
+              : msg
+          )
+        );
+      }
+    } finally {
+      setIsLoading(false);
+      abortControllerRef.current = null;
+    }
+  };
+
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto">
+        {messages.length === 0 ? (
+          <div className="flex flex-1 flex-col items-center justify-center px-4 py-8">
+            <div className="w-full max-w-2xl grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {config.suggestions.map((item) => (
+                <button
+                  key={item.title}
+                  onClick={() => setInput(item.prompt)}
+                  className="group flex flex-col gap-1 rounded-2xl border border-border bg-white p-4 text-left transition-all hover:border-summit/30 hover:shadow-lg hover:shadow-summit/5 hover:-translate-y-0.5"
+                >
+                  <p className="font-medium text-deep-blue">{item.title}</p>
+                  <p className="text-sm text-muted-foreground">{item.prompt}</p>
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="mx-auto max-w-3xl px-4">
+            {messages.map((message, index) => (
+              <ChatMessage
+                key={message.id}
+                role={message.role}
+                content={message.content}
+                isStreaming={
+                  isLoading &&
+                  index === messages.length - 1 &&
+                  message.role === "assistant"
+                }
+                onWorkflowOptionSelect={handleWorkflowFieldSelect}
+                onFollowUpSelect={handleWorkflowFollowUpSelect}
+                onFollowUpOther={(value) => handleSubmit(value)}
+              />
+            ))}
+            <div ref={messagesEndRef} className="h-4" />
+          </div>
+        )}
+      </div>
+
+      {/* Input */}
+      <div className="shrink-0 border-t border-border bg-gradient-to-t from-glacier to-transparent p-4">
+        <div className="mx-auto max-w-3xl">
+          <ChatInput
+            value={input}
+            onChange={setInput}
+            onSubmit={() => handleSubmit()}
+            onStop={handleStop}
+            isLoading={isLoading}
+            model={model}
+            onModelChange={setModel}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
+import { Separator } from "@/components/ui/separator";
+import { DashboardNavTabs, type TabKey } from "./dashboard-nav-tabs";
+import { ChatPanel } from "@/components/chat/chat-panel";
+import {
+  BookOpen,
+  BarChart3,
+  TrendingUp,
+  Users,
+  FileCheck,
+  Clock,
+  KanbanSquare,
+  CheckCircle2,
+  AlertCircle,
+} from "lucide-react";
+
+const SUB_PAGE_TITLES: Record<string, string> = {
+  "launch/onboarding": "Onboarding",
+  "launch/training": "Training Plans",
+  "launch/probation": "Probation Review",
+  "protect/warnings": "Written Warnings",
+  "protect/pip": "PIP Management",
+  "protect/compliance": "Compliance",
+  "attract/recruitment": "Recruitment",
+  "attract/engagement": "Engagement",
+  "attract/recognition": "Recognition",
+};
+
+interface DashboardContentProps {
+  activeSubPage: string;
+  activeTab: TabKey;
+  onTabChange: (tab: TabKey) => void;
+}
+
+function StatusContent({ subPage }: { subPage: string }) {
+  const title = SUB_PAGE_TITLES[subPage] || "All Workflows";
+
+  const stages = [
+    { label: "Draft", count: 3, icon: FileCheck, color: "bg-slate-100 text-slate-600" },
+    { label: "In Review", count: 2, icon: AlertCircle, color: "bg-amber-50 text-amber-600" },
+    { label: "Sent", count: 4, icon: KanbanSquare, color: "bg-blue-50 text-blue-600" },
+    { label: "Completed", count: 8, icon: CheckCircle2, color: "bg-emerald-50 text-emerald-600" },
+  ];
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {stages.map((stage) => (
+          <div key={stage.label} className="rounded-xl border bg-white p-5 shadow-sm">
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-sm font-medium text-muted-foreground">{stage.label}</span>
+              <div className={`flex size-8 items-center justify-center rounded-lg ${stage.color}`}>
+                <stage.icon className="size-4" />
+              </div>
+            </div>
+            <div className="text-3xl font-bold text-deep-blue">{stage.count}</div>
+            <p className="text-xs text-muted-foreground mt-1">documents</p>
+          </div>
+        ))}
+      </div>
+      <div className="rounded-xl border bg-white p-6 shadow-sm">
+        <div className="flex items-center gap-2 mb-4">
+          <KanbanSquare className="size-5 text-deep-blue" />
+          <h3 className="font-semibold text-deep-blue">{title} Pipeline</h3>
+        </div>
+        <div className="flex items-center justify-center h-48 text-muted-foreground text-sm border border-dashed rounded-lg">
+          Document pipeline view — connect to tracked documents
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LearnContent({ subPage }: { subPage: string }) {
+  const title = SUB_PAGE_TITLES[subPage] || "HR";
+  const isGeneral = !subPage;
+
+  const cards = isGeneral
+    ? [
+        {
+          title: "Getting Started with Ascenta",
+          description: "Learn how to use the platform to manage HR workflows end-to-end.",
+          icon: BookOpen,
+        },
+        {
+          title: "Company Policies",
+          description: "Review your organization's HR policies and compliance requirements.",
+          icon: FileCheck,
+        },
+        {
+          title: "Best Practices",
+          description: "Proven approaches for employee relations, performance management, and more.",
+          icon: Clock,
+        },
+      ]
+    : [
+        {
+          title: `${title} Basics`,
+          description: "Get started with foundational concepts and best practices.",
+          icon: BookOpen,
+        },
+        {
+          title: "Policy Guidelines",
+          description: "Review company policies and regulatory requirements.",
+          icon: FileCheck,
+        },
+        {
+          title: "Recent Updates",
+          description: "Stay current with the latest process changes and announcements.",
+          icon: Clock,
+        },
+      ];
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {cards.map((card) => (
+          <div
+            key={card.title}
+            className="rounded-xl border bg-white p-5 shadow-sm hover:shadow-md transition-shadow"
+          >
+            <div className="flex items-center gap-3 mb-3">
+              <div className="flex size-10 items-center justify-center rounded-lg bg-deep-blue/5">
+                <card.icon className="size-5 text-deep-blue" />
+              </div>
+              <h3 className="font-semibold text-deep-blue">{card.title}</h3>
+            </div>
+            <p className="text-sm text-muted-foreground">{card.description}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function InsightsContent({ subPage }: { subPage: string }) {
+  const title = SUB_PAGE_TITLES[subPage] || "Organization";
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {[
+          { label: "Active Cases", value: "12", icon: Users, change: "+2 this week" },
+          { label: "Completed", value: "47", icon: FileCheck, change: "+5 this month" },
+          { label: "Avg. Resolution", value: "8.3d", icon: Clock, change: "-1.2d vs last month" },
+          { label: "Compliance Rate", value: "96%", icon: TrendingUp, change: "+2% this quarter" },
+        ].map((stat) => (
+          <div
+            key={stat.label}
+            className="rounded-xl border bg-white p-5 shadow-sm"
+          >
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm text-muted-foreground">{stat.label}</span>
+              <stat.icon className="size-4 text-muted-foreground" />
+            </div>
+            <div className="text-2xl font-bold text-deep-blue">{stat.value}</div>
+            <p className="text-xs text-muted-foreground mt-1">{stat.change}</p>
+          </div>
+        ))}
+      </div>
+      <div className="rounded-xl border bg-white p-6 shadow-sm">
+        <div className="flex items-center gap-2 mb-4">
+          <BarChart3 className="size-5 text-deep-blue" />
+          <h3 className="font-semibold text-deep-blue">{title} Analytics</h3>
+        </div>
+        <div className="flex items-center justify-center h-48 text-muted-foreground text-sm border border-dashed rounded-lg">
+          Chart placeholder — connect analytics data source
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function DashboardContent({
+  activeSubPage,
+  activeTab,
+  onTabChange,
+}: DashboardContentProps) {
+  const pageTitle = activeSubPage ? (SUB_PAGE_TITLES[activeSubPage] ?? "Dashboard") : "Dashboard";
+
+  return (
+    <SidebarInset className="bg-glacier flex flex-col">
+      {/* Header */}
+      <header className="flex h-14 shrink-0 items-center gap-2 border-b bg-white px-4">
+        <SidebarTrigger className="-ml-1" />
+        <Separator orientation="vertical" className="mr-2 h-4" />
+        <h1 className="flex-1 font-display font-semibold text-deep-blue">
+          {pageTitle}
+        </h1>
+      </header>
+
+      {/* Tab Bar */}
+      <DashboardNavTabs activeTab={activeTab} onTabChange={onTabChange} />
+
+      {/* Content */}
+      {activeTab === "do" ? (
+        <ChatPanel subPage={activeSubPage} />
+      ) : (
+        <div className="flex-1 overflow-y-auto">
+          {activeTab === "learn" && <LearnContent subPage={activeSubPage} />}
+          {activeTab === "status" && <StatusContent subPage={activeSubPage} />}
+          {activeTab === "insights" && <InsightsContent subPage={activeSubPage} />}
+        </div>
+      )}
+    </SidebarInset>
+  );
+}

--- a/src/components/dashboard/dashboard-nav-tabs.tsx
+++ b/src/components/dashboard/dashboard-nav-tabs.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { MessageSquare, BookOpen, KanbanSquare, BarChart3 } from "lucide-react";
+
+type TabKey = "do" | "learn" | "status" | "insights";
+
+interface DashboardNavTabsProps {
+  activeTab: TabKey;
+  onTabChange: (tab: TabKey) => void;
+}
+
+const TABS: { key: TabKey; label: string; icon: React.ComponentType<{ className?: string }> }[] = [
+  { key: "do", label: "Do", icon: MessageSquare },
+  { key: "learn", label: "Learn", icon: BookOpen },
+  { key: "status", label: "Status", icon: KanbanSquare },
+  { key: "insights", label: "Insights", icon: BarChart3 },
+];
+
+export function DashboardNavTabs({ activeTab, onTabChange }: DashboardNavTabsProps) {
+  return (
+    <div className="flex items-center gap-1 border-b bg-white px-4">
+      {TABS.map((tab) => {
+        const isActive = activeTab === tab.key;
+        const Icon = tab.icon;
+
+        return (
+          <button
+            key={tab.key}
+            onClick={() => onTabChange(tab.key)}
+            className={cn(
+              "flex items-center gap-2 px-4 py-2.5 text-sm font-medium transition-colors relative",
+              "hover:text-deep-blue",
+              isActive
+                ? "text-deep-blue after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-summit"
+                : "text-muted-foreground"
+            )}
+          >
+            <Icon className="size-4" />
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export type { TabKey };

--- a/src/components/dashboard/dashboard-sidebar.tsx
+++ b/src/components/dashboard/dashboard-sidebar.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarRail,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
+} from "@/components/ui/sidebar";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Rocket,
+  Shield,
+  Magnet,
+  ChevronRight,
+  Mountain,
+  ChevronsUpDown,
+  LogOut,
+  UserCog,
+  Settings,
+  UserPlus,
+  BookOpen,
+  ClipboardCheck,
+  AlertTriangle,
+  FileText,
+  Scale,
+  Target,
+  Heart,
+  Award,
+  LayoutDashboard,
+} from "lucide-react";
+import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
+
+const CURRENT_USER = {
+  name: "Paul Stone",
+  email: "paul@ascenta.ai",
+  initials: "PS",
+  avatarUrl: "/avatars/user.jpg",
+};
+
+interface SubPage {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+}
+
+interface NavCategory {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  subPages: SubPage[];
+}
+
+const DASHBOARD_NAV: NavCategory[] = [
+  {
+    key: "launch",
+    label: "Launch",
+    icon: Rocket,
+    subPages: [
+      { key: "launch/onboarding", label: "Onboarding", icon: UserPlus },
+      { key: "launch/training", label: "Training Plans", icon: BookOpen },
+      { key: "launch/probation", label: "Probation Review", icon: ClipboardCheck },
+    ],
+  },
+  {
+    key: "protect",
+    label: "Protect",
+    icon: Shield,
+    subPages: [
+      { key: "protect/warnings", label: "Written Warnings", icon: AlertTriangle },
+      { key: "protect/pip", label: "PIP Management", icon: FileText },
+      { key: "protect/compliance", label: "Compliance", icon: Scale },
+    ],
+  },
+  {
+    key: "attract",
+    label: "Attract",
+    icon: Magnet,
+    subPages: [
+      { key: "attract/recruitment", label: "Recruitment", icon: Target },
+      { key: "attract/engagement", label: "Engagement", icon: Heart },
+      { key: "attract/recognition", label: "Recognition", icon: Award },
+    ],
+  },
+];
+
+interface DashboardSidebarProps {
+  activeSubPage: string;
+  onSubPageChange: (key: string) => void;
+}
+
+export function DashboardSidebar({
+  activeSubPage,
+  onSubPageChange,
+}: DashboardSidebarProps) {
+  const activeCategory = activeSubPage ? activeSubPage.split("/")[0] : "";
+
+  return (
+    <Sidebar collapsible="icon" className="sidebar-dark border-r-0">
+      {/* Header with Logo */}
+      <SidebarHeader className="border-b border-white/10">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              size="lg"
+              className="data-[state=open]:bg-white/10 data-[state=open]:text-white"
+              asChild
+            >
+              <Link href="/">
+                <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-gradient-to-br from-summit to-summit-hover text-white">
+                  <Mountain className="size-4" />
+                </div>
+                <div className="grid flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-display font-bold text-white">
+                    Ascenta
+                  </span>
+                  <span className="truncate text-xs text-slate-400">
+                    HR Platform
+                  </span>
+                </div>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+
+      {/* Home / Dashboard button */}
+      <SidebarGroup className="px-2 py-2">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              onClick={() => onSubPageChange("")}
+              isActive={!activeSubPage}
+              tooltip="Dashboard"
+              className="text-slate-300 hover:text-white hover:bg-white/10 data-[active=true]:text-summit data-[active=true]:bg-white/10"
+            >
+              <LayoutDashboard className="size-4" />
+              <span>Dashboard</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroup>
+
+      {/* Navigation Groups */}
+      <SidebarContent>
+        {DASHBOARD_NAV.map((category) => (
+          <Collapsible
+            key={category.key}
+            defaultOpen={category.key === activeCategory}
+            className="group/collapsible"
+          >
+            <SidebarGroup>
+              <SidebarGroupLabel asChild>
+                <CollapsibleTrigger className="flex w-full items-center gap-2 text-slate-400 hover:text-white">
+                  <category.icon className="size-4" />
+                  <span className="flex-1 text-left">{category.label}</span>
+                  <ChevronRight className="size-4 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+                </CollapsibleTrigger>
+              </SidebarGroupLabel>
+              <CollapsibleContent>
+                <SidebarGroupContent>
+                  <SidebarMenuSub>
+                    {category.subPages.map((subPage) => (
+                      <SidebarMenuSubItem key={subPage.key}>
+                        <SidebarMenuSubButton
+                          isActive={activeSubPage === subPage.key}
+                          onClick={() => onSubPageChange(subPage.key)}
+                          className="cursor-pointer text-slate-300 hover:text-white hover:bg-white/10 data-[active=true]:text-summit data-[active=true]:bg-white/10"
+                        >
+                          <subPage.icon className="size-4" />
+                          <span>{subPage.label}</span>
+                        </SidebarMenuSubButton>
+                      </SidebarMenuSubItem>
+                    ))}
+                  </SidebarMenuSub>
+                </SidebarGroupContent>
+              </CollapsibleContent>
+            </SidebarGroup>
+          </Collapsible>
+        ))}
+      </SidebarContent>
+
+      {/* Footer with User Profile */}
+      <SidebarFooter className="border-t border-white/10">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton
+                  size="lg"
+                  className="data-[state=open]:bg-white/10 data-[state=open]:text-white"
+                >
+                  <Avatar className="h-8 w-8 rounded-lg">
+                    <AvatarImage src={CURRENT_USER.avatarUrl} alt={CURRENT_USER.name} />
+                    <AvatarFallback className="rounded-lg bg-gradient-to-br from-summit to-summit-hover text-white font-medium">
+                      {CURRENT_USER.initials}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="grid flex-1 text-left text-sm leading-tight">
+                    <span className="truncate font-semibold text-white">
+                      {CURRENT_USER.name}
+                    </span>
+                    <span className="truncate text-xs text-slate-400">
+                      {CURRENT_USER.email}
+                    </span>
+                  </div>
+                  <ChevronsUpDown className="ml-auto size-4 text-slate-400" />
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+                side="top"
+                align="start"
+                sideOffset={4}
+              >
+                <DropdownMenuLabel className="p-0 font-normal">
+                  <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                    <Avatar className="h-8 w-8 rounded-lg">
+                      <AvatarImage src={CURRENT_USER.avatarUrl} alt={CURRENT_USER.name} />
+                      <AvatarFallback className="rounded-lg bg-gradient-to-br from-summit to-summit-hover text-white font-medium">
+                        {CURRENT_USER.initials}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="grid flex-1 text-left text-sm leading-tight">
+                      <span className="truncate font-semibold">{CURRENT_USER.name}</span>
+                      <span className="truncate text-xs text-muted-foreground">
+                        {CURRENT_USER.email}
+                      </span>
+                    </div>
+                  </div>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuGroup>
+                  <DropdownMenuItem className="cursor-pointer">
+                    <UserCog className="mr-2 size-4" />
+                    Switch Account
+                  </DropdownMenuItem>
+                  <DropdownMenuItem className="cursor-pointer">
+                    <Settings className="mr-2 size-4" />
+                    Settings
+                  </DropdownMenuItem>
+                </DropdownMenuGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem className="cursor-pointer text-red-600 focus:text-red-600 focus:bg-red-50">
+                  <LogOut className="mr-2 size-4" />
+                  Log out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+
+      <SidebarRail />
+    </Sidebar>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 
 const navLinks = [
   { href: "/product", label: "Product" },
+  { href: "/dashboard", label: "Dashboard" },
   { href: "/chat", label: "Chat" },
   { href: "/tracker", label: "Tracker" },
   { href: "/pricing", label: "Pricing" },


### PR DESCRIPTION
## Summary
- Adds `/dashboard` page with dark sidebar navigation (Launch, Protect, Attract categories with 3 sub-pages each)
- Each sub-page has Do/Learn/Status/Insights tabs with contextual content
- Do tab embeds a full AI chat panel (`ChatPanel`) with page-specific suggestion cards
- General landing page shown when no sub-page is selected
- Dashboard link added to main navbar

## Test plan
- [ ] Navigate to `/dashboard` — general landing page with Do tab active
- [ ] Click sidebar sub-pages — content and chat suggestions update per page
- [ ] Verify Do tab chat works (send messages, streaming, workflow interactions)
- [ ] Verify Learn/Status/Insights tabs show contextual placeholder content
- [ ] Click "Dashboard" sidebar button to return to general view
- [ ] Sidebar collapses to icon mode and expands back
- [ ] `npm run lint` passes with no new errors

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)