### PR TITLE
fix(schema): remove non-negotiable behaviors and lived principles

### DIFF
--- a/apps/platform/src/components/plan/foundation-panel.tsx
+++ b/apps/platform/src/components/plan/foundation-panel.tsx
@@ -6,18 +6,11 @@ import Link from "next/link";
 import { useRole } from "@/lib/role/role-context";
 import { MarkdownRenderer } from "@/components/chat/markdown-renderer";
 
-interface NamedItem {
-  name: string;
-  description: string;
-}
-
 interface FoundationData {
   id: string;
   mission: string;
   vision: string;
   values: string;
-  nonNegotiableBehaviors: NamedItem[];
-  livedPrinciples: NamedItem[];
   status: "draft" | "published";
   publishedAt: string | null;
   updatedAt: string;
@@ -43,94 +36,6 @@ const SECTIONS: { key: SectionKey; label: string; description: string }[] = [
   },
 ];
 
-function NamedItemListEditor({
-  items,
-  onChange,
-  onSave,
-  label,
-  description,
-  accentColor,
-  namePlaceholder,
-  descriptionPlaceholder,
-}: {
-  items: NamedItem[];
-  onChange: (items: NamedItem[]) => void;
-  onSave: () => void;
-  label: string;
-  description: string;
-  accentColor: string;
-  namePlaceholder: string;
-  descriptionPlaceholder: string;
-}) {
-  function updateItem(index: number, field: "name" | "description", value: string) {
-    const updated = [...items];
-    updated[index] = { ...updated[index], [field]: value };
-    onChange(updated);
-  }
-
-  function addItem() {
-    onChange([...items, { name: "", description: "" }]);
-  }
-
-  function removeItem(index: number) {
-    const updated = items.filter((_, i) => i !== index);
-    onChange(updated);
-    setTimeout(onSave, 0);
-  }
-
-  return (
-    <div className="rounded-xl border bg-white p-5 shadow-sm">
-      <div className="mb-3">
-        <h3 className="font-display text-base font-bold" style={{ color: accentColor }}>
-          {label}
-        </h3>
-        <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
-      </div>
-      <div className="space-y-3">
-        {items.map((item, i) => (
-          <div key={i} className="flex gap-2">
-            <div className="flex-1 space-y-1.5">
-              <input
-                value={item.name}
-                onChange={(e) => updateItem(i, "name", e.target.value)}
-                onBlur={onSave}
-                placeholder={namePlaceholder}
-                className="w-full rounded-lg border px-3 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-[--accent]"
-                style={{ "--accent": accentColor } as React.CSSProperties}
-              />
-              <textarea
-                value={item.description}
-                onChange={(e) => updateItem(i, "description", e.target.value)}
-                onBlur={onSave}
-                placeholder={descriptionPlaceholder}
-                rows={2}
-                className="w-full rounded-lg border px-3 py-2 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-[--accent] resize-y"
-                style={{ "--accent": accentColor } as React.CSSProperties}
-              />
-            </div>
-            <button
-              type="button"
-              onClick={() => removeItem(i)}
-              className="shrink-0 self-start mt-2 text-muted-foreground hover:text-destructive transition-colors"
-              title="Remove"
-            >
-              <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6L6 18M6 6l12 12" /></svg>
-            </button>
-          </div>
-        ))}
-        <button
-          type="button"
-          onClick={addItem}
-          className="flex items-center gap-1.5 rounded-lg border border-dashed px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors w-full justify-center"
-        >
-          <svg className="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M12 5v14M5 12h14" /></svg>
-          Add {label.replace(/s$/, "")}
-        </button>
-      </div>
-    </div>
-  );
-}
-
 interface FoundationPanelProps {
   accentColor: string;
 }
@@ -147,8 +52,6 @@ export function FoundationPanel({ accentColor }: FoundationPanelProps) {
     mission: "",
     vision: "",
     values: "",
-    nonNegotiableBehaviors: [] as NamedItem[],
-    livedPrinciples: [] as NamedItem[],
   });
 
   const fetchFoundation = useCallback(async () => {
@@ -163,8 +66,6 @@ export function FoundationPanel({ accentColor }: FoundationPanelProps) {
             mission: data.foundation.mission,
             vision: data.foundation.vision,
             values: data.foundation.values,
-            nonNegotiableBehaviors: data.foundation.nonNegotiableBehaviors ?? [],
-            livedPrinciples: data.foundation.livedPrinciples ?? [],
           });
           setEditMode(data.foundation.status === "draft");
         } else {
@@ -361,39 +262,6 @@ export function FoundationPanel({ accentColor }: FoundationPanelProps) {
                 </div>
               ))}
 
-              {/* Non-Negotiable Behaviors */}
-              {foundation.nonNegotiableBehaviors && foundation.nonNegotiableBehaviors.length > 0 && (
-                <div className="px-8 py-6 border-t border-border/50">
-                  <h4 className="font-display text-sm font-bold text-deep-blue mb-2.5">
-                    Non-Negotiable Behaviors
-                  </h4>
-                  <div className="space-y-3">
-                    {foundation.nonNegotiableBehaviors.map((item: NamedItem, i: number) => (
-                      <div key={i}>
-                        <p className="text-sm font-semibold text-foreground">{item.name}</p>
-                        <p className="text-sm text-muted-foreground leading-relaxed">{item.description}</p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Lived Principles */}
-              {foundation.livedPrinciples && foundation.livedPrinciples.length > 0 && (
-                <div className="px-8 py-6 border-t border-border/50">
-                  <h4 className="font-display text-sm font-bold text-deep-blue mb-2.5">
-                    Lived Principles
-                  </h4>
-                  <div className="space-y-3">
-                    {foundation.livedPrinciples.map((item: NamedItem, i: number) => (
-                      <div key={i}>
-                        <p className="text-sm font-semibold text-foreground">{item.name}</p>
-                        <p className="text-sm text-muted-foreground leading-relaxed">{item.description}</p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
             </div>
           </div>
         </div>
@@ -485,29 +353,6 @@ export function FoundationPanel({ accentColor }: FoundationPanelProps) {
               />
             </div>
           ))}
-        </div>
-
-        <div className="space-y-5 mt-5">
-          <NamedItemListEditor
-            items={form.nonNegotiableBehaviors}
-            onChange={(items) => setForm((prev) => ({ ...prev, nonNegotiableBehaviors: items }))}
-            onSave={handleSave}
-            label="Non-Negotiable Behaviors"
-            description="What behaviors are absolutely required regardless of role or department?"
-            accentColor={accentColor}
-            namePlaceholder="Behavior name (e.g., Transparency in decision-making)"
-            descriptionPlaceholder="Describe what this looks like in practice..."
-          />
-          <NamedItemListEditor
-            items={form.livedPrinciples}
-            onChange={(items) => setForm((prev) => ({ ...prev, livedPrinciples: items }))}
-            onSave={handleSave}
-            label="Lived Principles"
-            description="What principles guide how work gets done day-to-day?"
-            accentColor={accentColor}
-            namePlaceholder="Principle name (e.g., Default to action over consensus)"
-            descriptionPlaceholder="Describe how this principle shows up in daily work..."
-          />
         </div>
 
         <div className="flex items-center justify-between mt-6 pt-4 border-t">

--- a/apps/platform/src/lib/ai/plan-tools.ts
+++ b/apps/platform/src/lib/ai/plan-tools.ts
@@ -53,20 +53,6 @@ After enough answers, synthesize into a vision statement using markdown formatti
 
 After enough answers, synthesize into 3-6 core values using markdown formatting — use **bold** for each value name followed by a dash and description (e.g., "**Empowerment** — We believe..."). Separate values with blank lines. Call updateWorkingDocument with { values: "..." }.
 
-**Non-Negotiable Behaviors questions (ask one at a time, AFTER values are done):**
-16. What behaviors are absolutely non-negotiable in your organization, regardless of role or department?
-17. What would you consider a fireable offense related to conduct or culture?
-18. What behaviors must every employee demonstrate, even under pressure?
-
-After enough answers, synthesize into 3-5 non-negotiable behaviors. Each should have a clear **name** and description. Call updateWorkingDocument with { nonNegotiableBehaviors: [{ name: "...", description: "..." }, ...] }.
-
-**Lived Principles questions (ask one at a time, AFTER behaviors):**
-19. What principles guide how decisions are made day-to-day?
-20. When two good options conflict, what tiebreaker principles does your team use?
-21. What would a new hire need to internalize to fit in culturally?
-
-After enough answers, synthesize into 3-5 lived principles with **name** and description. Call updateWorkingDocument with { livedPrinciples: [{ name: "...", description: "..." }, ...] }.
-
 RULES:
 - Ask ONE question at a time. Wait for the user's response before asking the next.
 - You don't need to ask ALL questions — if the user gives rich answers, you can skip ahead.
@@ -81,7 +67,7 @@ RULES:
   }),
   execute: async (params) => {
     // Load existing foundation data if available
-    let existing = { mission: "", vision: "", values: "", nonNegotiableBehaviors: [] as { name: string; description: string }[], livedPrinciples: [] as { name: string; description: string }[] };
+    let existing = { mission: "", vision: "", values: "" };
     try {
       await connectDB();
       const doc = await CompanyFoundation.findOne();
@@ -90,8 +76,6 @@ RULES:
           mission: doc.mission || "",
           vision: doc.vision || "",
           values: doc.values || "",
-          nonNegotiableBehaviors: doc.nonNegotiableBehaviors ?? [],
-          livedPrinciples: doc.livedPrinciples ?? [],
         };
       }
     } catch {
@@ -102,8 +86,6 @@ RULES:
       mission: params.existingMission ?? existing.mission,
       vision: params.existingVision ?? existing.vision,
       values: params.existingValues ?? existing.values,
-      nonNegotiableBehaviors: existing.nonNegotiableBehaviors,
-      livedPrinciples: existing.livedPrinciples,
     };
 
     const hasExisting = existing.mission || existing.vision || existing.values;

--- a/apps/platform/src/lib/ai/strategy-tools.ts
+++ b/apps/platform/src/lib/ai/strategy-tools.ts
@@ -117,8 +117,6 @@ export const getStrategyBreakdownTool = tool({
             mission: (foundation as Record<string, unknown>).mission,
             vision: (foundation as Record<string, unknown>).vision,
             values: (foundation as Record<string, unknown>).values,
-            nonNegotiableBehaviors: (foundation as Record<string, unknown>).nonNegotiableBehaviors ?? [],
-            livedPrinciples: (foundation as Record<string, unknown>).livedPrinciples ?? [],
           }
         : null,
       companyGoals: (companyGoals as Record<string, unknown>[]).map((g) => ({

--- a/apps/platform/src/lib/ai/translation-engine.ts
+++ b/apps/platform/src/lib/ai/translation-engine.ts
@@ -164,12 +164,6 @@ export async function generateTranslationForDepartment(
   const mission = (foundation.mission as string) || "";
   const vision = (foundation.vision as string) || "";
   const values = (foundation.values as string) || "";
-  const nonNegotiableBehaviors = (
-    foundation.nonNegotiableBehaviors as { name: string; description: string }[] ?? []
-  );
-  const livedPrinciples = (
-    foundation.livedPrinciples as { name: string; description: string }[] ?? []
-  );
 
   const goalsContext = strategyGoals.map((g) => {
     const goal = g as Record<string, unknown>;
@@ -214,14 +208,8 @@ ${mission}
 VISION (shapes forward-looking outcomes — outcomes should move toward this vision):
 ${vision}
 
-CORE VALUES (each value must produce a behavioral expectation for this role):
+CORE VALUES (each value must produce a behavioral expectation for this role — values also set the floor for "poor" alignment descriptors):
 ${values}
-
-NON-NEGOTIABLE BEHAVIORS (these set the floor for "poor" alignment descriptors — failure to demonstrate these defines poor alignment regardless of other performance):
-${nonNegotiableBehaviors.map((b) => `- ${b.name}: ${b.description}`).join("\n") || "None defined"}
-
-LIVED PRINCIPLES (woven into how contribution and decision rights are described):
-${livedPrinciples.map((p) => `- ${p.name}: ${p.description}`).join("\n") || "None defined"}
 
 STRATEGIC PRIORITIES:
 ${goalsContext.map((g) => `- [${g.horizon}] [${g.scope}] "${g.title}": ${g.description}${g.rationale ? ` (Rationale: ${g.rationale})` : ""}`).join("\n")}
@@ -234,7 +222,7 @@ RULES FOR GENERATION:
 5. Alignment descriptors must be concrete:
    - "Strong" describes what excellent looks like with specific behaviors
    - "Acceptable" describes meeting expectations adequately
-   - "Poor" MUST reference non-negotiable behavior failures when relevant
+   - "Poor" MUST reference value violations when relevant
 6. For short-term priorities, produce more tactical, immediate language.
 7. For long-term priorities, produce more developmental and capability-building language.
 8. Every piece of language should feel like it was written for THIS specific role, not copy-pasted across roles.`;

--- a/apps/platform/src/lib/validations/foundation.ts
+++ b/apps/platform/src/lib/validations/foundation.ts
@@ -1,16 +1,9 @@
 import { z } from "zod";
 
-const namedItemSchema = z.object({
-  name: z.string().min(1, "Name is required"),
-  description: z.string().min(1, "Description is required"),
-});
-
 export const foundationFormSchema = z.object({
   mission: z.string().max(2000, "Mission must be 2000 characters or fewer").optional().default(""),
   vision: z.string().max(2000, "Vision must be 2000 characters or fewer").optional().default(""),
   values: z.string().max(2000, "Values must be 2000 characters or fewer").optional().default(""),
-  nonNegotiableBehaviors: z.array(namedItemSchema).optional().default([]),
-  livedPrinciples: z.array(namedItemSchema).optional().default([]),
 });
 
 export type FoundationFormValues = z.infer<typeof foundationFormSchema>;

--- a/apps/platform/src/lib/validations/strategy-translation.ts
+++ b/apps/platform/src/lib/validations/strategy-translation.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 export const alignmentDescriptorsSchema = z.object({
   strong: z.string().describe("What strong alignment looks like for this role relative to this priority"),
   acceptable: z.string().describe("What acceptable alignment looks like"),
-  poor: z.string().describe("What poor alignment looks like — anchored to non-negotiable behaviors"),
+  poor: z.string().describe("What poor alignment looks like — anchored to core value violations"),
 });
 
 export const contributionOutputSchema = z.object({

--- a/docs/reqs/strategy-studio.md
+++ b/docs/reqs/strategy-studio.md
@@ -13,7 +13,6 @@ Strategic Translation converts high-level organizational strategy into language 
 - [x] Leadership can define the organization's **mission** (why it exists)
 - [x] Leadership can define the organization's **vision** (where it is headed)
 - [x] Leadership can define **core values** that shape culture
-- [x] Leadership can define **non-negotiable behaviors** and lived principles
 - [x] Foundation elements are persisted and serve as cultural anchor for all translated outputs
 
 ## Screen 2: Strategic Priorities
@@ -39,7 +38,7 @@ For each department and function, the translation generates:
 
 - [x] **Role Contribution** — what each role is expected to contribute toward each strategic priority
 - [x] **Outcomes** — measurable results demonstrating alignment between the role and the priority
-- [x] **Behaviors** — observable actions reflecting core values and lived principles within the role context
+- [x] **Behaviors** — observable actions reflecting core values within the role context
 - [x] **Decision Rights** — clarity on what each level of contributor is empowered to decide, recommend, or escalate
 - [x] **Alignment Descriptors** — what strong, acceptable, and poor alignment looks like for each role relative to each priority
 
@@ -49,8 +48,7 @@ Each translated output must be shaped by the pillars in these specific ways:
 
 - [x] **Mission** anchors every role contribution statement to the reason the organization exists
 - [x] **Vision** shapes forward-looking outcomes and growth indicators within each role
-- [x] **Core Values** define behavioral expectations embedded in every role (woven in, not a separate section)
-- [x] **Non-Negotiable Behaviors** set the floor for alignment descriptors (poor alignment defined in part by failure to demonstrate these)
+- [x] **Core Values** define behavioral expectations embedded in every role and set the floor for alignment descriptors (woven in, not a separate section)
 - [x] **Strategic Priorities** determine the substance of each role contribution statement, mapped to priorities and horizons
 - [x] **Planning Horizons** calibrate expectations by timeframe:
   - [x] Short-term priorities produce immediate, tactical role language

--- a/packages/db/src/foundation-schema.ts
+++ b/packages/db/src/foundation-schema.ts
@@ -1,13 +1,5 @@
 import mongoose, { Schema } from "mongoose";
 
-const namedItemSchema = new Schema(
-  {
-    name: { type: String, required: true },
-    description: { type: String, required: true },
-  },
-  { _id: false },
-);
-
 const toJSONOptions = {
   virtuals: true,
   transform(_doc: unknown, ret: Record<string, unknown>) {
@@ -23,8 +15,6 @@ const foundationSchema = new Schema(
     mission: { type: String, default: "" },
     vision: { type: String, default: "" },
     values: { type: String, default: "" },
-    nonNegotiableBehaviors: { type: [namedItemSchema], default: [] },
-    livedPrinciples: { type: [namedItemSchema], default: [] },
     status: {
       type: String,
       enum: ["draft", "published"],

--- a/scripts/seed-strategy.ts
+++ b/scripts/seed-strategy.ts
@@ -87,38 +87,6 @@ async function main() {
       "A world where every employee has a clear path to growth, every manager has the tools to lead effectively, and every organization can build a thriving, high-performance culture — powered by AI that amplifies human judgment rather than replacing it.",
     values:
       "People First — Every feature we build starts with the question: does this make someone's work life better?\n\nTransparency by Default — We believe in open communication, clear expectations, and honest feedback at every level.\n\nContinuous Growth — We invest in learning, embrace feedback, and measure progress — for our customers and ourselves.\n\nAccountable Autonomy — We trust our people to own their work, make decisions, and deliver results with integrity.\n\nPragmatic Innovation — We use technology to solve real problems, not to chase trends. AI should make work simpler, not more complex.",
-    nonNegotiableBehaviors: [
-      {
-        name: "Transparency in Decision-Making",
-        description: "Every significant decision must be explainable to anyone affected by it. No black-box choices, no hidden agendas.",
-      },
-      {
-        name: "Psychological Safety in Feedback",
-        description: "Feedback flows in all directions without fear of retaliation. Dissent is welcomed when respectful and constructive.",
-      },
-      {
-        name: "Data Before Opinion",
-        description: "When data is available, it leads the conversation. Gut feel is a starting point, not a conclusion.",
-      },
-      {
-        name: "Follow Through on Commitments",
-        description: "If you commit to something, deliver it or renegotiate early. Ghosting on commitments erodes trust faster than anything else.",
-      },
-    ],
-    livedPrinciples: [
-      {
-        name: "Default to Action Over Consensus",
-        description: "When a decision is reversible and low-risk, move forward. Don't wait for perfect alignment when progress is possible.",
-      },
-      {
-        name: "Own the Outcome, Not Just the Task",
-        description: "Completing your assignment isn't enough. If the outcome isn't right, keep pushing until it is or escalate clearly.",
-      },
-      {
-        name: "Teach What You Learn",
-        description: "Knowledge shared is knowledge multiplied. Document, demo, and debrief so the team levels up together.",
-      },
-    ],
     status: "published",
     publishedAt: daysAgo(30),
   });
@@ -251,8 +219,6 @@ async function main() {
 
   console.log("=== Seed Summary ===");
   console.log(`  Foundation:       1 document (${foundation.status})`);
-  console.log(`    Behaviors:      ${foundation.nonNegotiableBehaviors.length}`);
-  console.log(`    Principles:     ${foundation.livedPrinciples.length}`);
   console.log(`  Strategy Goals:   ${strategyGoals.length} total`);
   console.log(`    Company-wide:   ${companyGoals.length}`);
   console.log(`    Department:     ${deptGoals.length} across ${departments.length} departments (${departments.join(", ")})`);


### PR DESCRIPTION
## Summary
- Removes `nonNegotiableBehaviors` and `livedPrinciples` fields from foundation schema, validation, UI, AI tools, translation engine, and seed data
- Core values already capture the same behavioral expectations — these were redundant complexity
- Updates strategy-studio.md requirements to reflect the removal

## Test plan
- [ ] Foundation page loads without errors (both published and edit views)
- [ ] Foundation publish/unpublish still works
- [ ] Compass MVV conversation flow works without non-negotiable/lived principles questions
- [ ] Strategy translation generation still works (uses core values for alignment descriptors)
- [ ] Strategy breakdown tool returns foundation without removed fields

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)