### PR TITLE
feat(translations): inline editing + per-section regeneration

### DIFF
--- a/apps/platform/src/app/api/plan/strategy-translations/[id]/route.ts
+++ b/apps/platform/src/app/api/plan/strategy-translations/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { connectDB } from "@ascenta/db";
 import { StrategyTranslation } from "@ascenta/db/strategy-translation-schema";
+import { regenerateRoleSection, type TranslationSection } from "@/lib/ai/translation-engine";
 
 export async function GET(
   _req: NextRequest,
@@ -80,6 +81,27 @@ export async function PATCH(
       });
     }
 
+    if (action === "regenerateSection") {
+      const { roleIndex, section } = body as {
+        roleIndex: number;
+        section: TranslationSection;
+      };
+
+      if (typeof roleIndex !== "number" || !["contributions", "behaviors", "decisionRights"].includes(section)) {
+        return NextResponse.json(
+          { success: false, error: "roleIndex (number) and section ('contributions' | 'behaviors' | 'decisionRights') are required" },
+          { status: 400 },
+        );
+      }
+
+      await regenerateRoleSection(id, roleIndex, section);
+
+      return NextResponse.json({
+        success: true,
+        message: `Regenerated ${section} for role at index ${roleIndex}.`,
+      });
+    }
+
     if (body.roles) {
       doc.roles = body.roles;
       await doc.save();
@@ -91,7 +113,7 @@ export async function PATCH(
     }
 
     return NextResponse.json(
-      { success: false, error: "Invalid action. Use 'publish', 'archive', or provide 'roles'." },
+      { success: false, error: "Invalid action. Use 'publish', 'archive', 'regenerateSection', or provide 'roles'." },
       { status: 400 },
     );
   } catch (error) {

--- a/apps/platform/src/components/plan/translation-role-preview.tsx
+++ b/apps/platform/src/components/plan/translation-role-preview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { memo } from "react";
+import { Loader2, RefreshCw } from "lucide-react";
 import { cn } from "@ascenta/ui";
 import { ROLE_LEVEL_LABELS } from "@ascenta/db/strategy-translation-constants";
 
@@ -31,6 +32,8 @@ interface TranslationRolePreviewProps {
   accentColor: string;
   editing?: boolean;
   onFieldChange?: (field: string, value: unknown) => void;
+  onRegenerateSection?: (section: "contributions" | "behaviors" | "decisionRights") => void;
+  regeneratingSection?: string | null;
 }
 
 export const TranslationRolePreview = memo(function TranslationRolePreview({
@@ -42,6 +45,8 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
   accentColor,
   editing,
   onFieldChange,
+  onRegenerateSection,
+  regeneratingSection,
 }: TranslationRolePreviewProps) {
   const levelLabel = ROLE_LEVEL_LABELS[level as keyof typeof ROLE_LEVEL_LABELS] ?? level;
 
@@ -67,6 +72,25 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
       </div>
 
       {/* Contributions per priority */}
+      {onRegenerateSection && !editing && (
+        <div className="flex items-center justify-between">
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Role Contributions
+          </p>
+          <button
+            onClick={() => onRegenerateSection("contributions")}
+            disabled={!!regeneratingSection}
+            className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-40"
+          >
+            {regeneratingSection === "contributions" ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <RefreshCw className="size-3" />
+            )}
+            Regenerate
+          </button>
+        </div>
+      )}
       {contributions.map((c, i) => (
         <div key={i} className="space-y-2">
           <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
@@ -172,9 +196,25 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
       {/* Behaviors */}
       {(behaviors.length > 0 || editing) && (
         <div>
-          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-            Behavioral Expectations
-          </p>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Behavioral Expectations
+            </p>
+            {onRegenerateSection && !editing && (
+              <button
+                onClick={() => onRegenerateSection("behaviors")}
+                disabled={!!regeneratingSection}
+                className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-40"
+              >
+                {regeneratingSection === "behaviors" ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <RefreshCw className="size-3" />
+                )}
+                Regenerate
+              </button>
+            )}
+          </div>
           <div className="space-y-2">
             {behaviors.map((b, i) => (
               <div key={i}>
@@ -233,9 +273,25 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
 
       {/* Decision Rights */}
       <div>
-        <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-          Decision Rights
-        </p>
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Decision Rights
+          </p>
+          {onRegenerateSection && !editing && (
+            <button
+              onClick={() => onRegenerateSection("decisionRights")}
+              disabled={!!regeneratingSection}
+              className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-40"
+            >
+              {regeneratingSection === "decisionRights" ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3" />
+              )}
+              Regenerate
+            </button>
+          )}
+        </div>
         <div className="grid grid-cols-3 gap-3">
           {(["canDecide", "canRecommend", "mustEscalate"] as const).map((key) => {
             const label = key === "canDecide" ? "Can Decide" : key === "canRecommend" ? "Can Recommend" : "Must Escalate";

--- a/apps/platform/src/components/plan/translation-role-preview.tsx
+++ b/apps/platform/src/components/plan/translation-role-preview.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import { cn } from "@ascenta/ui";
 import { ROLE_LEVEL_LABELS } from "@ascenta/db/strategy-translation-constants";
 
@@ -28,17 +29,24 @@ interface TranslationRolePreviewProps {
   behaviors: Behavior[];
   decisionRights: DecisionRights;
   accentColor: string;
+  editing?: boolean;
+  onFieldChange?: (field: string, value: unknown) => void;
 }
 
-export function TranslationRolePreview({
+export const TranslationRolePreview = memo(function TranslationRolePreview({
   jobTitle,
   level,
   contributions,
   behaviors,
   decisionRights,
   accentColor,
+  editing,
+  onFieldChange,
 }: TranslationRolePreviewProps) {
   const levelLabel = ROLE_LEVEL_LABELS[level as keyof typeof ROLE_LEVEL_LABELS] ?? level;
+
+  const inputCls = "w-full rounded-lg border px-3 py-2 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-[--accent] resize-y";
+  const inputStyle = { "--accent": accentColor } as React.CSSProperties;
 
   return (
     <div className="rounded-xl border bg-white p-5 shadow-sm space-y-5">
@@ -64,21 +72,75 @@ export function TranslationRolePreview({
           <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
             {c.strategyGoalTitle}
           </p>
-          <p className="text-sm text-foreground leading-relaxed">
-            {c.roleContribution}
-          </p>
-          {c.outcomes.length > 0 && (
-            <div>
-              <p className="text-[11px] font-semibold text-muted-foreground mb-1">
-                Success Outcomes
-              </p>
+
+          {editing ? (
+            <textarea
+              value={c.roleContribution}
+              onChange={(e) => onFieldChange?.(`contributions.${i}.roleContribution`, e.target.value)}
+              rows={3}
+              className={inputCls}
+              style={inputStyle}
+            />
+          ) : (
+            <p className="text-sm text-foreground leading-relaxed">
+              {c.roleContribution}
+            </p>
+          )}
+
+          {/* Outcomes */}
+          <div>
+            <p className="text-[11px] font-semibold text-muted-foreground mb-1">
+              Success Outcomes
+            </p>
+            {editing ? (
+              <div className="space-y-1.5">
+                {c.outcomes.map((o, j) => (
+                  <div key={j} className="flex gap-1.5">
+                    <input
+                      value={o}
+                      onChange={(e) => {
+                        const updated = [...c.outcomes];
+                        updated[j] = e.target.value;
+                        onFieldChange?.(`contributions.${i}.outcomes`, updated);
+                      }}
+                      className="flex-1 rounded-lg border px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[--accent]"
+                      style={inputStyle}
+                    />
+                    {c.outcomes.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const updated = c.outcomes.filter((_, k) => k !== j);
+                          onFieldChange?.(`contributions.${i}.outcomes`, updated);
+                        }}
+                        className="shrink-0 text-muted-foreground hover:text-destructive transition-colors px-1"
+                      >
+                        <svg className="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6L6 18M6 6l12 12" /></svg>
+                      </button>
+                    )}
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => {
+                    const updated = [...c.outcomes, ""];
+                    onFieldChange?.(`contributions.${i}.outcomes`, updated);
+                  }}
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  + Add outcome
+                </button>
+              </div>
+            ) : c.outcomes.length > 0 ? (
               <ul className="list-disc list-inside space-y-0.5">
                 {c.outcomes.map((o, j) => (
                   <li key={j} className="text-sm text-muted-foreground">{o}</li>
                 ))}
               </ul>
-            </div>
-          )}
+            ) : null}
+          </div>
+
+          {/* Alignment Descriptors */}
           <div className="grid grid-cols-3 gap-2 mt-2">
             {(["strong", "acceptable", "poor"] as const).map((lvl) => (
               <div
@@ -91,7 +153,16 @@ export function TranslationRolePreview({
                 )}
               >
                 <p className="font-semibold capitalize mb-0.5">{lvl}</p>
-                <p className="leading-relaxed">{c.alignmentDescriptors[lvl]}</p>
+                {editing ? (
+                  <textarea
+                    value={c.alignmentDescriptors[lvl]}
+                    onChange={(e) => onFieldChange?.(`contributions.${i}.alignmentDescriptors.${lvl}`, e.target.value)}
+                    rows={3}
+                    className="w-full rounded border px-2 py-1 text-xs leading-relaxed resize-y bg-white/50 focus:outline-none"
+                  />
+                ) : (
+                  <p className="leading-relaxed">{c.alignmentDescriptors[lvl]}</p>
+                )}
               </div>
             ))}
           </div>
@@ -99,7 +170,7 @@ export function TranslationRolePreview({
       ))}
 
       {/* Behaviors */}
-      {behaviors.length > 0 && (
+      {(behaviors.length > 0 || editing) && (
         <div>
           <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
             Behavioral Expectations
@@ -107,10 +178,55 @@ export function TranslationRolePreview({
           <div className="space-y-2">
             {behaviors.map((b, i) => (
               <div key={i}>
-                <span className="text-sm font-medium text-foreground">{b.valueName}:</span>{" "}
-                <span className="text-sm text-muted-foreground">{b.expectation}</span>
+                {editing ? (
+                  <div className="flex gap-2">
+                    <input
+                      value={b.valueName}
+                      onChange={(e) => onFieldChange?.(`behaviors.${i}.valueName`, e.target.value)}
+                      className="w-40 shrink-0 rounded-lg border px-2 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-[--accent]"
+                      style={inputStyle}
+                      placeholder="Value name"
+                    />
+                    <input
+                      value={b.expectation}
+                      onChange={(e) => onFieldChange?.(`behaviors.${i}.expectation`, e.target.value)}
+                      className="flex-1 rounded-lg border px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[--accent]"
+                      style={inputStyle}
+                      placeholder="Behavioral expectation"
+                    />
+                    {behaviors.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const updated = behaviors.filter((_, k) => k !== i);
+                          onFieldChange?.("behaviors", updated);
+                        }}
+                        className="shrink-0 text-muted-foreground hover:text-destructive transition-colors px-1"
+                      >
+                        <svg className="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6L6 18M6 6l12 12" /></svg>
+                      </button>
+                    )}
+                  </div>
+                ) : (
+                  <>
+                    <span className="text-sm font-medium text-foreground">{b.valueName}:</span>{" "}
+                    <span className="text-sm text-muted-foreground">{b.expectation}</span>
+                  </>
+                )}
               </div>
             ))}
+            {editing && (
+              <button
+                type="button"
+                onClick={() => {
+                  const updated = [...behaviors, { valueName: "", expectation: "" }];
+                  onFieldChange?.("behaviors", updated);
+                }}
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                + Add behavior
+              </button>
+            )}
           </div>
         </div>
       )}
@@ -121,32 +237,65 @@ export function TranslationRolePreview({
           Decision Rights
         </p>
         <div className="grid grid-cols-3 gap-3">
-          <div>
-            <p className="text-xs font-semibold text-emerald-700 mb-1">Can Decide</p>
-            <ul className="space-y-0.5">
-              {decisionRights.canDecide.map((d, i) => (
-                <li key={i} className="text-xs text-muted-foreground">• {d}</li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <p className="text-xs font-semibold text-amber-700 mb-1">Can Recommend</p>
-            <ul className="space-y-0.5">
-              {decisionRights.canRecommend.map((d, i) => (
-                <li key={i} className="text-xs text-muted-foreground">• {d}</li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <p className="text-xs font-semibold text-rose-700 mb-1">Must Escalate</p>
-            <ul className="space-y-0.5">
-              {decisionRights.mustEscalate.map((d, i) => (
-                <li key={i} className="text-xs text-muted-foreground">• {d}</li>
-              ))}
-            </ul>
-          </div>
+          {(["canDecide", "canRecommend", "mustEscalate"] as const).map((key) => {
+            const label = key === "canDecide" ? "Can Decide" : key === "canRecommend" ? "Can Recommend" : "Must Escalate";
+            const colorCls = key === "canDecide" ? "text-emerald-700" : key === "canRecommend" ? "text-amber-700" : "text-rose-700";
+            const items = decisionRights[key];
+
+            return (
+              <div key={key}>
+                <p className={cn("text-xs font-semibold mb-1", colorCls)}>{label}</p>
+                {editing ? (
+                  <div className="space-y-1">
+                    {items.map((d, i) => (
+                      <div key={i} className="flex gap-1">
+                        <input
+                          value={d}
+                          onChange={(e) => {
+                            const updated = [...items];
+                            updated[i] = e.target.value;
+                            onFieldChange?.(`decisionRights.${key}`, updated);
+                          }}
+                          className="flex-1 rounded border px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-[--accent]"
+                          style={inputStyle}
+                        />
+                        {items.length > 1 && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              const updated = items.filter((_, k) => k !== i);
+                              onFieldChange?.(`decisionRights.${key}`, updated);
+                            }}
+                            className="text-muted-foreground hover:text-destructive text-[10px]"
+                          >
+                            ✕
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const updated = [...items, ""];
+                        onFieldChange?.(`decisionRights.${key}`, updated);
+                      }}
+                      className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      + Add
+                    </button>
+                  </div>
+                ) : (
+                  <ul className="space-y-0.5">
+                    {items.map((d, i) => (
+                      <li key={i} className="text-xs text-muted-foreground">• {d}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>
   );
-}
+});

--- a/apps/platform/src/components/plan/translation-role-preview.tsx
+++ b/apps/platform/src/components/plan/translation-role-preview.tsx
@@ -31,8 +31,10 @@ interface TranslationRolePreviewProps {
   decisionRights: DecisionRights;
   accentColor: string;
   editing?: boolean;
-  onFieldChange?: (field: string, value: unknown) => void;
-  onRegenerateSection?: (section: "contributions" | "behaviors" | "decisionRights") => void;
+  roleIndex?: number;
+  translationId?: string;
+  onFieldChange?: (roleIndex: number, field: string, value: unknown) => void;
+  onRegenerateSection?: (translationId: string, roleIndex: number, section: "contributions" | "behaviors" | "decisionRights") => void;
   regeneratingSection?: string | null;
 }
 
@@ -44,6 +46,8 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
   decisionRights,
   accentColor,
   editing,
+  roleIndex = 0,
+  translationId = "",
   onFieldChange,
   onRegenerateSection,
   regeneratingSection,
@@ -78,7 +82,7 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
             Role Contributions
           </p>
           <button
-            onClick={() => onRegenerateSection("contributions")}
+            onClick={() => onRegenerateSection(translationId, roleIndex,"contributions")}
             disabled={!!regeneratingSection}
             className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-40"
           >
@@ -100,7 +104,7 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
           {editing ? (
             <textarea
               value={c.roleContribution}
-              onChange={(e) => onFieldChange?.(`contributions.${i}.roleContribution`, e.target.value)}
+              onChange={(e) => onFieldChange?.(roleIndex,`contributions.${i}.roleContribution`, e.target.value)}
               rows={3}
               className={inputCls}
               style={inputStyle}
@@ -125,7 +129,7 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
                       onChange={(e) => {
                         const updated = [...c.outcomes];
                         updated[j] = e.target.value;
-                        onFieldChange?.(`contributions.${i}.outcomes`, updated);
+                        onFieldChange?.(roleIndex,`contributions.${i}.outcomes`, updated);
                       }}
                       className="flex-1 rounded-lg border px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[--accent]"
                       style={inputStyle}
@@ -135,7 +139,7 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
                         type="button"
                         onClick={() => {
                           const updated = c.outcomes.filter((_, k) => k !== j);
-                          onFieldChange?.(`contributions.${i}.outcomes`, updated);
+                          onFieldChange?.(roleIndex,`contributions.${i}.outcomes`, updated);
                         }}
                         className="shrink-0 text-muted-foreground hover:text-destructive transition-colors px-1"
                       >
@@ -148,7 +152,7 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
                   type="button"
                   onClick={() => {
                     const updated = [...c.outcomes, ""];
-                    onFieldChange?.(`contributions.${i}.outcomes`, updated);
+                    onFieldChange?.(roleIndex,`contributions.${i}.outcomes`, updated);
                   }}
                   className="text-xs text-muted-foreground hover:text-foreground transition-colors"
                 >
@@ -180,7 +184,7 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
                 {editing ? (
                   <textarea
                     value={c.alignmentDescriptors[lvl]}
-                    onChange={(e) => onFieldChange?.(`contributions.${i}.alignmentDescriptors.${lvl}`, e.target.value)}
+                    onChange={(e) => onFieldChange?.(roleIndex,`contributions.${i}.alignmentDescriptors.${lvl}`, e.target.value)}
                     rows={3}
                     className="w-full rounded border px-2 py-1 text-xs leading-relaxed resize-y bg-white/50 focus:outline-none"
                   />
@@ -202,7 +206,7 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
             </p>
             {onRegenerateSection && !editing && (
               <button
-                onClick={() => onRegenerateSection("behaviors")}
+                onClick={() => onRegenerateSection(translationId, roleIndex,"behaviors")}
                 disabled={!!regeneratingSection}
                 className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-40"
               >
@@ -222,14 +226,14 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
                   <div className="flex gap-2">
                     <input
                       value={b.valueName}
-                      onChange={(e) => onFieldChange?.(`behaviors.${i}.valueName`, e.target.value)}
+                      onChange={(e) => onFieldChange?.(roleIndex,`behaviors.${i}.valueName`, e.target.value)}
                       className="w-40 shrink-0 rounded-lg border px-2 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-[--accent]"
                       style={inputStyle}
                       placeholder="Value name"
                     />
                     <input
                       value={b.expectation}
-                      onChange={(e) => onFieldChange?.(`behaviors.${i}.expectation`, e.target.value)}
+                      onChange={(e) => onFieldChange?.(roleIndex,`behaviors.${i}.expectation`, e.target.value)}
                       className="flex-1 rounded-lg border px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[--accent]"
                       style={inputStyle}
                       placeholder="Behavioral expectation"
@@ -239,7 +243,7 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
                         type="button"
                         onClick={() => {
                           const updated = behaviors.filter((_, k) => k !== i);
-                          onFieldChange?.("behaviors", updated);
+                          onFieldChange?.(roleIndex,"behaviors", updated);
                         }}
                         className="shrink-0 text-muted-foreground hover:text-destructive transition-colors px-1"
                       >
@@ -260,7 +264,7 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
                 type="button"
                 onClick={() => {
                   const updated = [...behaviors, { valueName: "", expectation: "" }];
-                  onFieldChange?.("behaviors", updated);
+                  onFieldChange?.(roleIndex,"behaviors", updated);
                 }}
                 className="text-xs text-muted-foreground hover:text-foreground transition-colors"
               >
@@ -279,7 +283,7 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
           </p>
           {onRegenerateSection && !editing && (
             <button
-              onClick={() => onRegenerateSection("decisionRights")}
+              onClick={() => onRegenerateSection(translationId, roleIndex,"decisionRights")}
               disabled={!!regeneratingSection}
               className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-40"
             >
@@ -310,7 +314,7 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
                           onChange={(e) => {
                             const updated = [...items];
                             updated[i] = e.target.value;
-                            onFieldChange?.(`decisionRights.${key}`, updated);
+                            onFieldChange?.(roleIndex,`decisionRights.${key}`, updated);
                           }}
                           className="flex-1 rounded border px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-[--accent]"
                           style={inputStyle}
@@ -320,7 +324,7 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
                             type="button"
                             onClick={() => {
                               const updated = items.filter((_, k) => k !== i);
-                              onFieldChange?.(`decisionRights.${key}`, updated);
+                              onFieldChange?.(roleIndex,`decisionRights.${key}`, updated);
                             }}
                             className="text-muted-foreground hover:text-destructive text-[10px]"
                           >
@@ -333,7 +337,7 @@ export const TranslationRolePreview = memo(function TranslationRolePreview({
                       type="button"
                       onClick={() => {
                         const updated = [...items, ""];
-                        onFieldChange?.(`decisionRights.${key}`, updated);
+                        onFieldChange?.(roleIndex,`decisionRights.${key}`, updated);
                       }}
                       className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
                     >

--- a/apps/platform/src/components/plan/translations-panel.tsx
+++ b/apps/platform/src/components/plan/translations-panel.tsx
@@ -51,6 +51,11 @@ export function TranslationsPanel({ accentColor }: TranslationsPanelProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editRoles, setEditRoles] = useState<Role[]>([]);
   const [saving, setSaving] = useState(false);
+  const [regeneratingSection, setRegeneratingSection] = useState<{
+    translationId: string;
+    roleIndex: number;
+    section: string;
+  } | null>(null);
 
   const fetchTranslations = useCallback(async () => {
     try {
@@ -177,6 +182,30 @@ export function TranslationsPanel({ accentColor }: TranslationsPanelProps) {
       target[parts[parts.length - 1]] = value;
       return updated;
     });
+  }
+
+  async function handleRegenerateSection(
+    translationId: string,
+    roleIndex: number,
+    section: "contributions" | "behaviors" | "decisionRights",
+  ) {
+    setRegeneratingSection({ translationId, roleIndex, section });
+    try {
+      const res = await fetch(`/api/plan/strategy-translations/${translationId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "regenerateSection", roleIndex, section }),
+      });
+      const data = await res.json();
+      if (!data.success) {
+        setError(data.error ?? "Regeneration failed");
+      }
+      await fetchTranslations();
+    } catch {
+      setError("Section regeneration failed");
+    } finally {
+      setRegeneratingSection(null);
+    }
   }
 
   if (loading) {
@@ -376,6 +405,16 @@ export function TranslationsPanel({ accentColor }: TranslationsPanelProps) {
                             accentColor={accentColor}
                             editing={editingId === translation.id}
                             onFieldChange={(field, value) => handleFieldChange(i, field, value)}
+                            onRegenerateSection={editingId !== translation.id
+                              ? (section) => handleRegenerateSection(translation.id, i, section)
+                              : undefined
+                            }
+                            regeneratingSection={
+                              regeneratingSection?.translationId === translation.id &&
+                              regeneratingSection?.roleIndex === i
+                                ? regeneratingSection.section
+                                : null
+                            }
                           />
                         ))}
                       </div>

--- a/apps/platform/src/components/plan/translations-panel.tsx
+++ b/apps/platform/src/components/plan/translations-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Loader2, Languages, RefreshCw, ChevronRight, AlertTriangle } from "lucide-react";
+import { Loader2, Languages, RefreshCw, ChevronRight, AlertTriangle, Pencil, Check } from "lucide-react";
 import { cn } from "@ascenta/ui";
 import { TRANSLATION_STATUS_LABELS } from "@ascenta/db/strategy-translation-constants";
 import { TranslationRolePreview } from "./translation-role-preview";
@@ -48,6 +48,9 @@ export function TranslationsPanel({ accentColor }: TranslationsPanelProps) {
   const [generating, setGenerating] = useState<string | null>(null);
   const [expandedDept, setExpandedDept] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editRoles, setEditRoles] = useState<Role[]>([]);
+  const [saving, setSaving] = useState(false);
 
   const fetchTranslations = useCallback(async () => {
     try {
@@ -127,6 +130,53 @@ export function TranslationsPanel({ accentColor }: TranslationsPanelProps) {
       body: JSON.stringify({ action: "archive" }),
     });
     fetchTranslations();
+  }
+
+  function handleStartEdit(translation: TranslationData) {
+    setEditingId(translation.id);
+    setEditRoles(JSON.parse(JSON.stringify(translation.roles)));
+  }
+
+  function handleCancelEdit() {
+    setEditingId(null);
+    setEditRoles([]);
+  }
+
+  async function handleSaveEdit(id: string) {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/plan/strategy-translations/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ roles: editRoles }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setEditingId(null);
+        setEditRoles([]);
+        fetchTranslations();
+      } else {
+        setError(data.error ?? "Save failed");
+      }
+    } catch {
+      setError("Failed to save edits");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleFieldChange(roleIndex: number, field: string, value: unknown) {
+    setEditRoles((prev) => {
+      const updated = JSON.parse(JSON.stringify(prev));
+      const parts = field.split(".");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let target: any = updated[roleIndex];
+      for (let i = 0; i < parts.length - 1; i++) {
+        target = target[parts[i]];
+      }
+      target[parts[parts.length - 1]] = value;
+      return updated;
+    });
   }
 
   if (loading) {
@@ -267,7 +317,35 @@ export function TranslationsPanel({ accentColor }: TranslationsPanelProps) {
                             )}
                             Regenerate
                           </button>
-                          {translation.status === "draft" && (
+                          {(translation.status === "draft" || translation.status === "published") && editingId !== translation.id && (
+                            <button
+                              onClick={() => handleStartEdit(translation)}
+                              className="flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+                            >
+                              <Pencil className="size-3" />
+                              Edit
+                            </button>
+                          )}
+                          {editingId === translation.id && (
+                            <>
+                              <button
+                                onClick={() => handleSaveEdit(translation.id)}
+                                disabled={saving}
+                                className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold text-white transition-colors disabled:opacity-40"
+                                style={{ backgroundColor: "#22c55e" }}
+                              >
+                                {saving ? <Loader2 className="size-3 animate-spin" /> : <Check className="size-3" />}
+                                Save
+                              </button>
+                              <button
+                                onClick={handleCancelEdit}
+                                className="rounded-lg border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+                              >
+                                Cancel
+                              </button>
+                            </>
+                          )}
+                          {translation.status === "draft" && editingId !== translation.id && (
                             <button
                               onClick={() => handlePublish(translation.id)}
                               className="rounded-lg px-3 py-1.5 text-xs font-semibold text-white transition-colors"
@@ -276,7 +354,7 @@ export function TranslationsPanel({ accentColor }: TranslationsPanelProps) {
                               Publish
                             </button>
                           )}
-                          {translation.status !== "archived" && (
+                          {translation.status !== "archived" && editingId !== translation.id && (
                             <button
                               onClick={() => handleArchive(translation.id)}
                               className="rounded-lg border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
@@ -287,7 +365,7 @@ export function TranslationsPanel({ accentColor }: TranslationsPanelProps) {
                         </div>
 
                         {/* Role previews */}
-                        {translation.roles.map((role, i) => (
+                        {(editingId === translation.id ? editRoles : translation.roles).map((role, i) => (
                           <TranslationRolePreview
                             key={i}
                             jobTitle={role.jobTitle}
@@ -296,6 +374,8 @@ export function TranslationsPanel({ accentColor }: TranslationsPanelProps) {
                             behaviors={role.behaviors}
                             decisionRights={role.decisionRights}
                             accentColor={accentColor}
+                            editing={editingId === translation.id}
+                            onFieldChange={(field, value) => handleFieldChange(i, field, value)}
                           />
                         ))}
                       </div>

--- a/apps/platform/src/components/plan/translations-panel.tsx
+++ b/apps/platform/src/components/plan/translations-panel.tsx
@@ -290,7 +290,13 @@ export function TranslationsPanel({ accentColor }: TranslationsPanelProps) {
               return (
                 <div key={dept} className="rounded-xl border bg-white shadow-sm overflow-hidden">
                   <button
-                    onClick={() => setExpandedDept(isExpanded ? null : dept)}
+                    onClick={() => {
+                      if (isExpanded && editingId === translation.id) {
+                        if (!confirm("You have unsaved edits. Discard changes?")) return;
+                        handleCancelEdit();
+                      }
+                      setExpandedDept(isExpanded ? null : dept);
+                    }}
                     className="flex w-full items-center gap-3 px-5 py-4 text-left"
                   >
                     <span className="flex-1 font-display text-sm font-semibold text-deep-blue">
@@ -404,11 +410,10 @@ export function TranslationsPanel({ accentColor }: TranslationsPanelProps) {
                             decisionRights={role.decisionRights}
                             accentColor={accentColor}
                             editing={editingId === translation.id}
-                            onFieldChange={(field, value) => handleFieldChange(i, field, value)}
-                            onRegenerateSection={editingId !== translation.id
-                              ? (section) => handleRegenerateSection(translation.id, i, section)
-                              : undefined
-                            }
+                            roleIndex={i}
+                            translationId={translation.id}
+                            onFieldChange={editingId === translation.id ? handleFieldChange : undefined}
+                            onRegenerateSection={editingId !== translation.id ? handleRegenerateSection : undefined}
                             regeneratingSection={
                               regeneratingSection?.translationId === translation.id &&
                               regeneratingSection?.roleIndex === i

--- a/apps/platform/src/lib/ai/translation-engine.ts
+++ b/apps/platform/src/lib/ai/translation-engine.ts
@@ -11,7 +11,13 @@ import { CompanyFoundation } from "@ascenta/db/foundation-schema";
 import { StrategyGoal } from "@ascenta/db/strategy-goal-schema";
 import { Employee } from "@ascenta/db/employee-schema";
 import { StrategyTranslation } from "@ascenta/db/strategy-translation-schema";
-import { roleTranslationOutputSchema } from "@/lib/validations/strategy-translation";
+import { z } from "zod";
+import {
+  roleTranslationOutputSchema,
+  contributionOutputSchema,
+  behaviorOutputSchema,
+  decisionRightsOutputSchema,
+} from "@/lib/validations/strategy-translation";
 
 // ---------------------------------------------------------------------------
 // Role level inference from job title
@@ -85,6 +91,97 @@ export async function checkTranslationStaleness(
   }
 
   return { isStale: reasons.length > 0, reasons };
+}
+
+// ---------------------------------------------------------------------------
+// Per-section regeneration
+// ---------------------------------------------------------------------------
+
+export type TranslationSection = "contributions" | "behaviors" | "decisionRights";
+
+export async function regenerateRoleSection(
+  translationId: string,
+  roleIndex: number,
+  section: TranslationSection,
+): Promise<void> {
+  await connectDB();
+
+  const translationDoc = await StrategyTranslation.findById(translationId);
+  if (!translationDoc) throw new Error("Translation not found");
+
+  const role = translationDoc.roles[roleIndex];
+  if (!role) throw new Error(`Role at index ${roleIndex} not found`);
+
+  const foundationDoc = await CompanyFoundation.findOne({ status: "published" }).lean();
+  if (!foundationDoc) throw new Error("No published foundation found.");
+  const foundation = foundationDoc as Record<string, unknown>;
+
+  const department = translationDoc.department as string;
+  const strategyGoals = await StrategyGoal.find({
+    $or: [
+      { scope: "company", status: { $ne: "archived" } },
+      { scope: "department", department, status: { $ne: "archived" } },
+    ],
+  }).lean();
+
+  const mission = (foundation.mission as string) || "";
+  const vision = (foundation.vision as string) || "";
+  const values = (foundation.values as string) || "";
+
+  const goalsContext = strategyGoals.map((g) => {
+    const goal = g as Record<string, unknown>;
+    return {
+      id: String(goal._id),
+      title: goal.title as string,
+      description: goal.description as string,
+      horizon: goal.horizon as string,
+      scope: goal.scope as string,
+      rationale: (goal.rationale as string) || "",
+    };
+  });
+
+  const jobTitle = role.jobTitle as string;
+  const level = role.level as string;
+
+  const availability = checkProviderConfig();
+  let modelId: string;
+  if (availability.openai) {
+    modelId = AI_CONFIG.defaultModels.openai;
+  } else if (availability.anthropic) {
+    modelId = AI_CONFIG.defaultModels.anthropic;
+  } else {
+    throw new Error("No AI provider configured.");
+  }
+
+  const baseContext = `MISSION: ${mission}\nVISION: ${vision}\nCORE VALUES: ${values}\n\nSTRATEGIC PRIORITIES:\n${goalsContext.map((g) => `- [${g.horizon}] [${g.scope}] "${g.title}": ${g.description}`).join("\n")}\n\nRole: ${jobTitle} (${level}) in ${department}`;
+
+  if (section === "contributions") {
+    const result = await generateObject({
+      model: getModel(modelId),
+      schema: z.object({ contributions: z.array(contributionOutputSchema) }),
+      system: `You are regenerating ONLY the contribution statements for a specific role. Keep the same quality standards: mission-anchored contributions, measurable outcomes, concrete alignment descriptors.\n\n${baseContext}`,
+      prompt: `Regenerate contribution statements for ${jobTitle} (${level}) for EACH of these goals:\n${goalsContext.map((g) => `- ID: ${g.id}, Title: "${g.title}" (${g.horizon}, ${g.scope})`).join("\n")}`,
+    });
+    translationDoc.roles[roleIndex].contributions = result.object.contributions;
+  } else if (section === "behaviors") {
+    const result = await generateObject({
+      model: getModel(modelId),
+      schema: z.object({ behaviors: z.array(behaviorOutputSchema) }),
+      system: `You are regenerating ONLY the behavioral expectations for a specific role. Each behavior must derive from a core value and be observable.\n\n${baseContext}`,
+      prompt: `Regenerate behavioral expectations for ${jobTitle} (${level}). Create one behavior per core value.`,
+    });
+    translationDoc.roles[roleIndex].behaviors = result.object.behaviors;
+  } else if (section === "decisionRights") {
+    const result = await generateObject({
+      model: getModel(modelId),
+      schema: z.object({ decisionRights: decisionRightsOutputSchema }),
+      system: `You are regenerating ONLY the decision rights for a specific role. Calibrate to role level: executives decide broadly, managers within teams, ICs within their scope.\n\n${baseContext}`,
+      prompt: `Regenerate decision rights for ${jobTitle} (${level}). Produce canDecide, canRecommend, and mustEscalate lists.`,
+    });
+    translationDoc.roles[roleIndex].decisionRights = result.object.decisionRights;
+  }
+
+  await translationDoc.save();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **#33 — Editing support:** Adds inline edit mode to TranslationRolePreview with per-field editing for all sections (contributions, outcomes, alignment descriptors, behaviors, decision rights). Edit/Save/Cancel controls in TranslationsPanel with deep-copy state management and PATCH save.
- **#36 — Per-section regeneration:** New `regenerateRoleSection()` engine function for targeted AI regeneration. New PATCH action `regenerateSection` on the individual translation route. Per-section "Regenerate" buttons in role preview (hidden during edit mode).

## Test plan
- [ ] Expand a department, click Edit — all fields become editable inputs/textareas
- [ ] Edit a contribution text, click Save — verify change persists after refresh
- [ ] Click Cancel — verify changes revert
- [ ] Add/remove outcomes, behaviors, decision rights items while editing
- [ ] Click per-section Regenerate on contributions — spinner shows, only contributions update
- [ ] Click per-section Regenerate on behaviors — only behaviors regenerate
- [ ] Click per-section Regenerate on decisionRights — only decision rights regenerate
- [ ] Verify regenerate buttons hidden during edit mode
- [ ] Verify no console errors

Closes #33, closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)