### PR TITLE
feat(grow): suggested outcomes on Goals tab with Compass fast-path

### DIFF
--- a/apps/platform/src/app/api/chat/route.ts
+++ b/apps/platform/src/app/api/chat/route.ts
@@ -57,6 +57,8 @@ interface ChatRequest {
   requiredTool?: string;
   /** Current logged-in employee context — skips need for getEmployeeInfo */
   currentEmployee?: { id: string; employeeId?: string; firstName: string; lastName: string; department: string; title: string };
+  /** Pre-selected outcome context from role translation — triggers fast-path goal creation */
+  outcomeContext?: { outcomeText: string; strategyGoalId: string; strategyGoalTitle: string; contributionRef: string };
 }
 
 export async function POST(req: Request) {
@@ -75,6 +77,7 @@ export async function POST(req: Request) {
       activeWorkflowRunId,
       requiredTool,
       currentEmployee,
+      outcomeContext,
     } = body;
 
     const isWorkflowAction = !!(workflowFieldSelection || workflowFollowUp);
@@ -176,6 +179,10 @@ export async function POST(req: Request) {
     // Inject required tool hint when user has pre-selected a tool
     if (requiredTool) {
       effectiveSystemPrompt += `\n\n[REQUIRED_TOOL] You MUST use the ${requiredTool} tool in your response. The user has explicitly requested this tool be used.${currentEmployee ? " Use the current user info from [CURRENT_USER] above — do NOT call getEmployeeInfo." : " Look up the employee first with getEmployeeInfo if needed, then"} Call ${requiredTool} as soon as you have enough information. Ask minimal clarifying questions only if truly necessary. [/REQUIRED_TOOL]`;
+    }
+
+    if (outcomeContext) {
+      effectiveSystemPrompt += `\n\n[OUTCOME_CONTEXT] The user has pre-selected an outcome from their role translation:\n- Outcome: "${outcomeContext.outcomeText}"\n- Strategy Goal: "${outcomeContext.strategyGoalTitle}" (ID: ${outcomeContext.strategyGoalId})\n- Role Contribution: "${outcomeContext.contributionRef}"\nSkip Steps 1-3. Default goalType to "performance". Use this outcome as the basis for the objective statement. Go directly to Step 4: suggest 1-3 key results for this outcome, discuss time period and support, then call openGoalDocument with strategyGoalId, strategyGoalTitle, and contributionRef pre-filled. [/OUTCOME_CONTEXT]`;
     }
 
     // Get the model instance

--- a/apps/platform/src/app/api/grow/suggested-outcomes/route.ts
+++ b/apps/platform/src/app/api/grow/suggested-outcomes/route.ts
@@ -17,7 +17,13 @@ export async function GET(req: NextRequest) {
       );
     }
 
-    const employee = await getEmployeeById(employeeId);
+    let employee;
+    try {
+      employee = await getEmployeeById(employeeId);
+    } catch {
+      // Invalid ObjectId format
+      return NextResponse.json({ outcomes: [] });
+    }
     if (!employee) {
       return NextResponse.json({ outcomes: [] });
     }

--- a/apps/platform/src/app/api/grow/suggested-outcomes/route.ts
+++ b/apps/platform/src/app/api/grow/suggested-outcomes/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { connectDB } from "@ascenta/db";
+import { getEmployeeById } from "@ascenta/db/employees";
+import { getTranslationForEmployee } from "@/lib/ai/translation-lookup";
+
+export async function GET(req: NextRequest) {
+  try {
+    await connectDB();
+
+    const { searchParams } = new URL(req.url);
+    const employeeId = searchParams.get("employeeId");
+
+    if (!employeeId) {
+      return NextResponse.json(
+        { success: false, error: "employeeId query parameter is required" },
+        { status: 400 },
+      );
+    }
+
+    const employee = await getEmployeeById(employeeId);
+    if (!employee) {
+      return NextResponse.json({ outcomes: [] });
+    }
+
+    const translation = await getTranslationForEmployee(
+      employee.department,
+      employee.jobTitle,
+    );
+
+    if (!translation) {
+      return NextResponse.json({ outcomes: [] });
+    }
+
+    const outcomes: {
+      text: string;
+      strategyGoalId: string;
+      strategyGoalTitle: string;
+      roleContribution: string;
+    }[] = [];
+
+    for (const contribution of translation.contributions) {
+      for (const outcomeText of contribution.outcomes) {
+        outcomes.push({
+          text: outcomeText,
+          strategyGoalId: contribution.strategyGoalId,
+          strategyGoalTitle: contribution.strategyGoalTitle,
+          roleContribution: contribution.roleContribution,
+        });
+      }
+    }
+
+    return NextResponse.json({ outcomes });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("Suggested outcomes GET error:", message);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch suggested outcomes" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/platform/src/app/do/page.tsx
+++ b/apps/platform/src/app/do/page.tsx
@@ -22,6 +22,10 @@ function DoPageInner() {
     if (hasSeededRef.current) return;
     const prompt = searchParams.get("prompt");
     const toolKey = searchParams.get("tool");
+    const outcomeText = searchParams.get("outcomeText");
+    const strategyGoalId = searchParams.get("strategyGoalId");
+    const strategyGoalTitle = searchParams.get("strategyGoalTitle");
+    const contributionRef = searchParams.get("contributionRef");
 
     if (prompt) {
       hasSeededRef.current = true;
@@ -38,7 +42,11 @@ function DoPageInner() {
               title: persona.title,
             }
           : undefined;
-        sendMessage("do", prompt, toolKey ?? undefined, employeeInfo);
+        const outcomeCtx =
+          outcomeText && strategyGoalId && strategyGoalTitle && contributionRef
+            ? { outcomeText, strategyGoalId, strategyGoalTitle, contributionRef }
+            : undefined;
+        sendMessage("do", prompt, toolKey ?? undefined, employeeInfo, outcomeCtx);
       }, 100);
     }
   }, [searchParams, setPageInput, sendMessage, persona]);

--- a/apps/platform/src/components/grow/goals-panel.tsx
+++ b/apps/platform/src/components/grow/goals-panel.tsx
@@ -46,6 +46,13 @@ interface GoalData {
   managerConfirmed: boolean;
 }
 
+interface SuggestedOutcome {
+  text: string;
+  strategyGoalId: string;
+  strategyGoalTitle: string;
+  roleContribution: string;
+}
+
 interface GoalsPanelProps {
   accentColor: string;
 }
@@ -94,6 +101,8 @@ export function GoalsPanel({ accentColor }: GoalsPanelProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [selectedEmployee, setSelectedEmployee] =
     useState<EmployeeOption | null>(null);
+  const [suggestedOutcomes, setSuggestedOutcomes] = useState<SuggestedOutcome[]>([]);
+  const [showAllOutcomes, setShowAllOutcomes] = useState(false);
 
   // The employee whose goals we're viewing
   const viewingEmployeeId = selectedEmployee?.id ?? persona?.id;
@@ -132,9 +141,26 @@ export function GoalsPanel({ accentColor }: GoalsPanelProps) {
     }
   }, [viewingEmployeeId, roleLoading]);
 
+  const fetchOutcomes = useCallback(async () => {
+    if (!viewingEmployeeId) return;
+    try {
+      const res = await fetch(
+        `/api/grow/suggested-outcomes?employeeId=${viewingEmployeeId}`,
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setSuggestedOutcomes(data.outcomes ?? []);
+      }
+    } catch {
+      // silent — section just won't render
+    }
+  }, [viewingEmployeeId]);
+
   useEffect(() => {
     fetchGoals();
-  }, [fetchGoals]);
+    fetchOutcomes();
+    setShowAllOutcomes(false);
+  }, [fetchGoals, fetchOutcomes]);
 
   if (loading) {
     return (
@@ -154,6 +180,19 @@ export function GoalsPanel({ accentColor }: GoalsPanelProps) {
         <p className="text-sm text-muted-foreground max-w-sm">{error}</p>
       </div>
     );
+  }
+
+  function buildOutcomeLink(outcome: SuggestedOutcome): string {
+    const prompt = `Create a goal based on this outcome: "${outcome.text}"`;
+    const params = new URLSearchParams({
+      prompt,
+      tool: "startGoalWorkflow",
+      outcomeText: outcome.text,
+      strategyGoalId: outcome.strategyGoalId,
+      strategyGoalTitle: outcome.strategyGoalTitle,
+      contributionRef: outcome.roleContribution,
+    });
+    return `/do?${params.toString()}`;
   }
 
   const draftGoals = goals.filter((g) => g.status === "draft");
@@ -495,6 +534,50 @@ export function GoalsPanel({ accentColor }: GoalsPanelProps) {
     );
   }
 
+  const suggestedOutcomesSection = suggestedOutcomes.length > 0 ? (
+    <div className="mt-6">
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+        Suggested Outcomes
+      </p>
+      <div className="space-y-2">
+        {(showAllOutcomes
+          ? suggestedOutcomes
+          : suggestedOutcomes.slice(0, 3)
+        ).map((outcome, i) => (
+          <div
+            key={`${outcome.strategyGoalId}-${i}`}
+            className="flex items-center justify-between rounded-lg border px-3 py-2.5"
+          >
+            <div className="flex-1 min-w-0 mr-3">
+              <p className="text-sm text-foreground truncate">
+                {outcome.text}
+              </p>
+              <p className="text-xs text-muted-foreground truncate mt-0.5">
+                {outcome.strategyGoalTitle}
+              </p>
+            </div>
+            <Link
+              href={buildOutcomeLink(outcome)}
+              className="flex items-center gap-1 shrink-0 text-xs font-medium transition-colors"
+              style={{ color: "#ff6b35" }}
+            >
+              <Compass className="size-3" />
+              Create with Compass
+            </Link>
+          </div>
+        ))}
+        {!showAllOutcomes && suggestedOutcomes.length > 3 && (
+          <button
+            onClick={() => setShowAllOutcomes(true)}
+            className="text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Show {suggestedOutcomes.length - 3} more
+          </button>
+        )}
+      </div>
+    </div>
+  ) : null;
+
   return (
     <div className="flex-1 overflow-y-auto p-6">
       <div className="max-w-4xl mx-auto">
@@ -596,58 +679,64 @@ export function GoalsPanel({ accentColor }: GoalsPanelProps) {
         )}
 
         {goals.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 text-center">
-            <Target className="size-10 text-muted-foreground/30 mb-3" />
-            <h3 className="font-display text-lg font-bold text-foreground mb-1">
-              No Goals Yet
-            </h3>
-            <p className="text-sm text-muted-foreground max-w-sm mb-4">
-              Get started by creating your first goal with Compass.
-            </p>
-            <Link
-              href="/do?prompt=Help%20me%20create%20a%20performance%20goal&tool=startGoalWorkflow"
-              className="flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold text-white transition-colors"
-              style={{ backgroundColor: "#ff6b35" }}
-            >
-              <Compass className="size-4" />
-              Create with Compass
-            </Link>
-          </div>
+          <>
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <Target className="size-10 text-muted-foreground/30 mb-3" />
+              <h3 className="font-display text-lg font-bold text-foreground mb-1">
+                No Goals Yet
+              </h3>
+              <p className="text-sm text-muted-foreground max-w-sm mb-4">
+                Get started by creating your first goal with Compass.
+              </p>
+              <Link
+                href="/do?prompt=Help%20me%20create%20a%20performance%20goal&tool=startGoalWorkflow"
+                className="flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold text-white transition-colors"
+                style={{ backgroundColor: "#ff6b35" }}
+              >
+                <Compass className="size-4" />
+                Create with Compass
+              </Link>
+            </div>
+            {suggestedOutcomesSection}
+          </>
         ) : (
-          <div className="space-y-5">
-            {draftGoals.length > 0 && (
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-                  Draft
-                </p>
-                {renderGoalTable(draftGoals)}
-              </div>
-            )}
-            {pendingGoals.length > 0 && (
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-                  Pending Confirmation
-                </p>
-                {renderGoalTable(pendingGoals)}
-              </div>
-            )}
-            {activeGoals.length > 0 && (
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-                  Active
-                </p>
-                {renderGoalTable(activeGoals)}
-              </div>
-            )}
-            {completedGoals.length > 0 && (
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-                  Completed
-                </p>
-                {renderGoalTable(completedGoals)}
-              </div>
-            )}
-          </div>
+          <>
+            <div className="space-y-5">
+              {draftGoals.length > 0 && (
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+                    Draft
+                  </p>
+                  {renderGoalTable(draftGoals)}
+                </div>
+              )}
+              {pendingGoals.length > 0 && (
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+                    Pending Confirmation
+                  </p>
+                  {renderGoalTable(pendingGoals)}
+                </div>
+              )}
+              {activeGoals.length > 0 && (
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+                    Active
+                  </p>
+                  {renderGoalTable(activeGoals)}
+                </div>
+              )}
+              {completedGoals.length > 0 && (
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+                    Completed
+                  </p>
+                  {renderGoalTable(completedGoals)}
+                </div>
+              )}
+            </div>
+            {suggestedOutcomesSection}
+          </>
         )}
       </div>
 

--- a/apps/platform/src/lib/ai/grow-tools.ts
+++ b/apps/platform/src/lib/ai/grow-tools.ts
@@ -169,6 +169,8 @@ If roleContributions are available in the tool response, use them as the PRIMARY
 **Step 4 — Key results and support:**
 Based on the objective, suggest 1-3 key results (more are allowed if needed). Each key result needs: what will be measured, the measurable target, and a deadline. Ask user to pick or customize. Discuss time period. Ask what support the manager can provide (resources, access, time, coaching). Then call openGoalDocument with all fields.
 
+**Fast-path:** If the system prompt contains [OUTCOME_CONTEXT], skip Steps 1-3 entirely. The strategic pillar and objective are already determined. Default goalType to "performance". Use the outcome text to draft the objective statement and proceed directly to Step 4 (key results, time period, support agreement). Ensure strategyGoalId, strategyGoalTitle, and contributionRef from the context are passed through to openGoalDocument.
+
 RULES:
 - Ask ONE question at a time. Wait for the response before moving on.
 - If the user gives rich answers, skip ahead where appropriate.

--- a/apps/platform/src/lib/chat/chat-context.tsx
+++ b/apps/platform/src/lib/chat/chat-context.tsx
@@ -45,7 +45,7 @@ export interface ChatContextValue {
   model: string;
   setModel: (model: string) => void;
   messagesEndRef: React.RefObject<HTMLDivElement | null>;
-  sendMessage: (pageKey: string, content: string, requiredTool?: string, currentEmployee?: { id: string; employeeId?: string; firstName: string; lastName: string; department: string; title: string }) => Promise<void>;
+  sendMessage: (pageKey: string, content: string, requiredTool?: string, currentEmployee?: { id: string; employeeId?: string; firstName: string; lastName: string; department: string; title: string }, outcomeContext?: { outcomeText: string; strategyGoalId: string; strategyGoalTitle: string; contributionRef: string }) => Promise<void>;
   setPageInput: (pageKey: string, value: string) => void;
   resetConversation: (pageKey: string) => void;
   stopGeneration: (pageKey: string) => void;
@@ -297,7 +297,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const sendMessage = useCallback(
-    async (pageKey: string, content: string, requiredTool?: string, currentEmployee?: { id: string; employeeId?: string; firstName: string; lastName: string; department: string; title: string }) => {
+    async (pageKey: string, content: string, requiredTool?: string, currentEmployee?: { id: string; employeeId?: string; firstName: string; lastName: string; department: string; title: string }, outcomeContext?: { outcomeText: string; strategyGoalId: string; strategyGoalTitle: string; contributionRef: string }) => {
       const trimmed = content.trim();
       const pageState = pageConversations.get(pageKey) ?? {
         ...DEFAULT_PAGE_STATE,
@@ -352,6 +352,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
             ...(activeWorkflowRunId ? { activeWorkflowRunId } : {}),
             ...(requiredTool ? { requiredTool } : {}),
             ...(currentEmployee ? { currentEmployee } : {}),
+            ...(outcomeContext ? { outcomeContext } : {}),
           }),
           signal: abortController.signal,
         });


### PR DESCRIPTION
## Summary

- Adds a "Suggested Outcomes" section below the goals table on the Goals tab, sourced from the employee's role translation (`roles.contributions.outcomes`)
- Shows first 3 outcomes with a "Show more" option to expand; hidden entirely when no translation exists
- Each outcome has a "Create with Compass" link that navigates to `/do` with outcome context, skipping Steps 1-3 of the goal creation conversation and going straight to key results refinement
- Threads `outcomeContext` through the chat pipeline (`/do` page → `sendMessage` → `/api/chat` → `[OUTCOME_CONTEXT]` system prompt block)

## Changes

| File | What |
|------|------|
| `apps/platform/src/app/api/grow/suggested-outcomes/route.ts` | New GET endpoint — employee lookup, translation fetch, flatten outcomes |
| `apps/platform/src/components/grow/goals-panel.tsx` | Fetch + render suggested outcomes section with 3-item limit and "Show more" |
| `apps/platform/src/app/do/page.tsx` | Read outcome params from URL, pass to sendMessage |
| `apps/platform/src/lib/chat/chat-context.tsx` | Extend sendMessage with optional outcomeContext param |
| `apps/platform/src/app/api/chat/route.ts` | Inject `[OUTCOME_CONTEXT]` block into system prompt |
| `apps/platform/src/lib/ai/grow-tools.ts` | Add fast-path instructions to startGoalWorkflow tool description |

## Test plan

- [ ] Navigate to Goals tab with a persona whose department has a published translation — verify "Suggested Outcomes" section appears below goals
- [ ] Verify only 3 outcomes shown initially, "Show more" expands to all
- [ ] Switch to a persona with no translation — verify section is hidden
- [ ] Click "Create with Compass" on an outcome — verify navigation to `/do` with correct params
- [ ] Verify Compass skips Steps 1-3 and goes directly to key results for the selected outcome
- [ ] Complete the full goal creation flow and verify strategyGoalId + contributionRef are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)