### PR TITLE
feat: performance reviews v2 Phase B — employee self-assessment UI

### DIFF
--- a/apps/platform/src/app/[category]/[sub]/page.tsx
+++ b/apps/platform/src/app/[category]/[sub]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useState } from "react";
+import { useAuth } from "@/lib/auth/auth-context";
 import { notFound } from "next/navigation";
 import {
   findNavContext,
@@ -15,6 +16,7 @@ import { LearnPanel } from "@/components/grow/learn-panel";
 import { GoalsPanel } from "@/components/grow/goals-panel";
 import { ReviewsPanel } from "@/components/grow/reviews-panel";
 import { CheckinsPanel } from "@/components/grow/checkins-panel";
+import { SelfAssessmentPanel } from "@/components/grow/performance-reviews/self-assessment-panel";
 
 export default function CategorySubPage({
   params,
@@ -29,6 +31,7 @@ export default function CategorySubPage({
   const pageConfig = PAGE_CONFIG[pageKey] || DEFAULT_PAGE_CONFIG;
   const tabs = pageConfig.tabs ?? FUNCTION_TABS;
   const [activeTab, setActiveTab] = useState<string>(tabs[0].key);
+  const { user } = useAuth();
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
@@ -72,11 +75,19 @@ export default function CategorySubPage({
         <CheckinsPanel accentColor={ctx.category.color} />
       ) : activeTab === "reviews" ? (
         <div className="flex-1 overflow-y-auto p-6">
-          <ReviewsPanel
-            pageKey={pageKey}
-            accentColor={ctx.category.color}
-            onSwitchToDoTab={() => setActiveTab("do")}
-          />
+          {user?.role === "employee" ? (
+            <SelfAssessmentPanel
+              employeeObjectId={user.id}
+              employeeName={user.name}
+              accentColor={ctx.category.color}
+            />
+          ) : (
+            <ReviewsPanel
+              pageKey={pageKey}
+              accentColor={ctx.category.color}
+              onSwitchToDoTab={() => setActiveTab("do")}
+            />
+          )}
         </div>
       ) : (
         <div className="flex-1 flex flex-col items-center justify-center text-center p-6">

--- a/apps/platform/src/app/api/grow/reviews/route.ts
+++ b/apps/platform/src/app/api/grow/reviews/route.ts
@@ -15,10 +15,32 @@ export async function GET(req: NextRequest) {
     const { searchParams } = new URL(req.url);
     const managerId = searchParams.get("managerId");
     const periodLabel = searchParams.get("period");
+    const employeeObjectId = searchParams.get("employeeObjectId");
+
+    if (employeeObjectId) {
+      // Employee view: reviews where this employee is the subject
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const employeeReviews = await PerformanceReview.find({ employee: employeeObjectId })
+        .sort({ "reviewPeriod.end": -1 })
+        .lean() as any[];
+
+      return NextResponse.json({
+        success: true,
+        reviews: employeeReviews.map((r) => ({
+          id: String(r._id),
+          employeeName: r.employeeName as string,
+          reviewPeriod: typeof r.reviewPeriod === "string"
+            ? r.reviewPeriod
+            : (r.reviewPeriod?.label as string | undefined) ?? String(r.reviewPeriod),
+          reviewType: (r.reviewType as string | undefined) ?? "custom",
+          selfAssessmentStatus: (r.selfAssessment?.status as string | undefined) ?? "not_started",
+        })),
+      });
+    }
 
     if (!managerId) {
       return NextResponse.json(
-        { success: false, error: "managerId is required" },
+        { success: false, error: "managerId or employeeObjectId is required" },
         { status: 400 },
       );
     }

--- a/apps/platform/src/app/api/grow/reviews/route.ts
+++ b/apps/platform/src/app/api/grow/reviews/route.ts
@@ -31,7 +31,7 @@ export async function GET(req: NextRequest) {
           employeeName: r.employeeName as string,
           reviewPeriod: typeof r.reviewPeriod === "string"
             ? r.reviewPeriod
-            : (r.reviewPeriod?.label as string | undefined) ?? String(r.reviewPeriod),
+            : (r.reviewPeriod?.label as string | undefined) ?? "",
           reviewType: (r.reviewType as string | undefined) ?? "custom",
           selfAssessmentStatus: (r.selfAssessment?.status as string | undefined) ?? "not_started",
         })),

--- a/apps/platform/src/components/grow/performance-reviews/category-section-card.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/category-section-card.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Textarea } from "@ascenta/ui/textarea";
+import { Label } from "@ascenta/ui/label";
+import { REVIEW_CATEGORIES, RATING_SCALE } from "@ascenta/db/performance-review-categories";
+import type { ReviewCategoryKey } from "@ascenta/db/performance-review-categories";
+import { LikertScale } from "@/components/grow/check-in/likert-scale";
+
+interface CategorySectionCardProps {
+  categoryKey: ReviewCategoryKey;
+  index: number;
+  rating: number | null;
+  notes: string;
+  examples: string;
+  disabled?: boolean;
+  onRatingChange: (rating: number) => void;
+  onNotesChange: (notes: string) => void;
+  onExamplesChange: (examples: string) => void;
+  onBlur?: () => void;
+}
+
+export function CategorySectionCard({
+  categoryKey,
+  index,
+  rating,
+  notes,
+  examples,
+  disabled = false,
+  onRatingChange,
+  onNotesChange,
+  onExamplesChange,
+  onBlur,
+}: CategorySectionCardProps) {
+  const category = REVIEW_CATEGORIES[categoryKey];
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-5 space-y-4">
+      {/* Header */}
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-foreground">
+          {index}. {category.label}
+        </h3>
+        <p className="text-xs text-muted-foreground">{category.definition}</p>
+      </div>
+
+      {/* Guided prompts */}
+      <ul className="space-y-1 pl-4 list-disc">
+        {category.guidedPrompts.map((prompt, i) => (
+          <li key={i} className="text-xs text-muted-foreground italic">
+            {prompt}
+          </li>
+        ))}
+      </ul>
+
+      {/* Rating */}
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Rating</Label>
+        <LikertScale
+          value={rating}
+          onChange={onRatingChange}
+          lowLabel={RATING_SCALE[1].label}
+          highLabel={RATING_SCALE[5].label}
+          disabled={disabled}
+        />
+        {rating !== null && rating >= 1 && rating <= 5 && (
+          <p className="text-xs text-muted-foreground text-center">
+            {RATING_SCALE[rating as keyof typeof RATING_SCALE].label} —{" "}
+            {RATING_SCALE[rating as keyof typeof RATING_SCALE].description}
+          </p>
+        )}
+      </div>
+
+      {/* Notes */}
+      <div className="space-y-1.5">
+        <Label htmlFor={`notes-${categoryKey}`} className="text-sm font-medium">
+          Notes
+        </Label>
+        <Textarea
+          id={`notes-${categoryKey}`}
+          value={notes}
+          onChange={(e) => onNotesChange(e.target.value)}
+          onBlur={onBlur}
+          disabled={disabled}
+          placeholder="Describe your performance in this area during the review period..."
+          className="min-h-[80px] resize-none"
+        />
+      </div>
+
+      {/* Specific Examples */}
+      <div className="space-y-1.5">
+        <Label htmlFor={`examples-${categoryKey}`} className="text-sm font-medium">
+          Specific Examples
+        </Label>
+        <Textarea
+          id={`examples-${categoryKey}`}
+          value={examples}
+          onChange={(e) => onExamplesChange(e.target.value)}
+          onBlur={onBlur}
+          disabled={disabled}
+          placeholder="List specific examples, achievements, or situations from the review period..."
+          className="min-h-[80px] resize-none"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/platform/src/components/grow/performance-reviews/self-assessment-form.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/self-assessment-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import { Button } from "@ascenta/ui/button";
 import { REVIEW_CATEGORY_KEYS } from "@ascenta/db/performance-review-categories";
 import type { ReviewCategoryKey, SelfAssessmentStatus } from "@ascenta/db/performance-review-categories";
@@ -52,17 +52,77 @@ export function SelfAssessmentForm({
   const [isSaving, setIsSaving] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(initialStatus === "submitted");
+  const [isLoadingInitial, setIsLoadingInitial] = useState(true);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sectionsRef = useRef<CategorySectionValue[]>(sections);
+  // Track whether status has already been advanced to "in_progress" so we only
+  // send that field on the very first save for a "not_started" review.
+  const hasFirstSavedRef = useRef(initialStatus !== "not_started");
+
+  // Bug 1: fetch persisted sections on mount so "Continue" restores prior work
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSections() {
+      try {
+        const res = await fetch(`/api/grow/reviews/${reviewId}`);
+        if (!res.ok || cancelled) return;
+
+        const data = await res.json();
+        const fetchedSections: CategorySectionValue[] =
+          data?.review?.selfAssessment?.sections ?? [];
+        const fetchedStatus: SelfAssessmentStatus =
+          data?.review?.selfAssessment?.status ?? initialStatus;
+
+        if (!cancelled) {
+          const built = buildInitialSections(fetchedSections);
+          setSections(built);
+          sectionsRef.current = built;
+          if (fetchedStatus === "submitted") {
+            setSubmitted(true);
+          }
+          // If the DB already shows in_progress (or submitted), no need to
+          // advance status again on the first save.
+          if (fetchedStatus !== "not_started") {
+            hasFirstSavedRef.current = true;
+          }
+        }
+      } finally {
+        if (!cancelled) setIsLoadingInitial(false);
+      }
+    }
+
+    loadSections();
+    return () => {
+      cancelled = true;
+    };
+  }, [reviewId, initialStatus]);
 
   const saveSections = useCallback(
     async (updatedSections: CategorySectionValue[]) => {
       setIsSaving(true);
       try {
-        await fetch(`/api/grow/reviews/${reviewId}`, {
+        // Bug 2: advance status to "in_progress" on the very first save
+        const body: Record<string, unknown> = { sections: updatedSections };
+        if (!hasFirstSavedRef.current) {
+          hasFirstSavedRef.current = true;
+          body.status = "in_progress";
+        }
+
+        const res = await fetch(`/api/grow/reviews/${reviewId}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ selfAssessment: { sections: updatedSections } }),
+          body: JSON.stringify({ selfAssessment: body }),
         });
+
+        // Medium fix A: surface save errors
+        if (!res.ok) {
+          setSaveError("Failed to save — please try again.");
+        } else {
+          setSaveError(null);
+        }
       } finally {
         setIsSaving(false);
       }
@@ -70,10 +130,17 @@ export function SelfAssessmentForm({
     [reviewId],
   );
 
+  // Bug 3c: cancel any pending debounce before saving the rating immediately
   const handleRatingChange = useCallback(
     (index: number, rating: number) => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
       setSections((prev) => {
+        // Bug 3a: keep sectionsRef in sync inside the updater
         const updated = prev.map((s, i) => (i === index ? { ...s, rating } : s));
+        sectionsRef.current = updated;
         saveSections(updated);
         return updated;
       });
@@ -83,31 +150,40 @@ export function SelfAssessmentForm({
 
   const handleTextChange = useCallback(
     (index: number, field: "notes" | "examples", value: string) => {
-      setSections((prev) => prev.map((s, i) => (i === index ? { ...s, [field]: value } : s)));
+      setSections((prev) => {
+        // Bug 3a: keep sectionsRef in sync inside the updater
+        const next = prev.map((s, i) => (i === index ? { ...s, [field]: value } : s));
+        sectionsRef.current = next;
+        return next;
+      });
     },
     [],
   );
 
-  const handleBlur = useCallback(
-    (currentSections: CategorySectionValue[]) => {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-      debounceRef.current = setTimeout(() => {
-        saveSections(currentSections);
-      }, 500);
-    },
-    [saveSections],
-  );
+  // Bug 3b: no argument — reads from sectionsRef to avoid stale closure
+  const handleBlur = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      saveSections(sectionsRef.current);
+    }, 500);
+  }, [saveSections]);
 
   const handleSubmit = useCallback(async () => {
     setIsSubmitting(true);
+    setSubmitError(null);
     try {
-      await fetch(`/api/grow/reviews/${reviewId}`, {
+      const res = await fetch(`/api/grow/reviews/${reviewId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ selfAssessment: { status: "submitted", sections } }),
       });
+
+      // Medium fix A: surface submit errors
+      if (!res.ok) {
+        setSubmitError("Failed to submit — please try again.");
+        return;
+      }
+
       setSubmitted(true);
       onSubmitted();
     } finally {
@@ -143,6 +219,8 @@ export function SelfAssessmentForm({
                 Submitted
               </span>
             </>
+          ) : saveError ? (
+            <span className="text-red-500">{saveError}</span>
           ) : isSaving ? (
             <>
               <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
@@ -154,44 +232,61 @@ export function SelfAssessmentForm({
         </div>
       </div>
 
-      {/* Category sections */}
-      <div className="space-y-4">
-        {sections.map((section, index) => (
-          <CategorySectionCard
-            key={section.categoryKey}
-            categoryKey={section.categoryKey}
-            index={index + 1}
-            rating={section.rating}
-            notes={section.notes}
-            examples={section.examples}
-            disabled={submitted}
-            onRatingChange={(rating) => handleRatingChange(index, rating)}
-            onNotesChange={(value) => handleTextChange(index, "notes", value)}
-            onExamplesChange={(value) => handleTextChange(index, "examples", value)}
-            onBlur={() => handleBlur(sections)}
-          />
-        ))}
-      </div>
-
-      {/* Submit row */}
-      {!submitted && (
-        <div className="flex justify-end pt-2">
-          <Button
-            onClick={handleSubmit}
-            disabled={isSubmitting}
-            className="text-white"
-            style={{ backgroundColor: accentColor }}
-          >
-            {isSubmitting ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Submitting…
-              </>
-            ) : (
-              "Submit Self-Assessment"
-            )}
-          </Button>
+      {/* Bug 1: show spinner while fetching persisted data */}
+      {isLoadingInitial ? (
+        <div className="flex justify-center py-10">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
         </div>
+      ) : (
+        <>
+          {/* Category sections */}
+          <div className="space-y-4">
+            {sections.map((section, index) => (
+              <CategorySectionCard
+                key={section.categoryKey}
+                categoryKey={section.categoryKey}
+                index={index + 1}
+                rating={section.rating}
+                notes={section.notes}
+                examples={section.examples}
+                disabled={submitted}
+                onRatingChange={(rating) => handleRatingChange(index, rating)}
+                onNotesChange={(value) => handleTextChange(index, "notes", value)}
+                onExamplesChange={(value) => handleTextChange(index, "examples", value)}
+                onBlur={handleBlur}
+              />
+            ))}
+          </div>
+
+          {/* Submit row */}
+          {!submitted && (
+            <div className="flex flex-col items-end gap-2 pt-2">
+              {/* Medium fix B: warn about unrated categories */}
+              {sections.some((s) => s.rating === null) && (
+                <p className="text-xs text-amber-600">
+                  {sections.filter((s) => s.rating === null).length} of 10 categories have no
+                  rating yet.
+                </p>
+              )}
+              {submitError && <p className="text-xs text-red-500">{submitError}</p>}
+              <Button
+                onClick={handleSubmit}
+                disabled={isSubmitting}
+                className="text-white"
+                style={{ backgroundColor: accentColor }}
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Submitting…
+                  </>
+                ) : (
+                  "Submit Self-Assessment"
+                )}
+              </Button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/apps/platform/src/components/grow/performance-reviews/self-assessment-form.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/self-assessment-form.tsx
@@ -18,7 +18,6 @@ interface SelfAssessmentFormProps {
   reviewId: string;
   employeeName: string;
   reviewPeriod: string;
-  initialSections: CategorySectionValue[];
   initialStatus: SelfAssessmentStatus;
   accentColor: string;
   onBack: () => void;
@@ -40,14 +39,13 @@ export function SelfAssessmentForm({
   reviewId,
   employeeName,
   reviewPeriod,
-  initialSections,
   initialStatus,
   accentColor,
   onBack,
   onSubmitted,
 }: SelfAssessmentFormProps) {
   const [sections, setSections] = useState<CategorySectionValue[]>(() =>
-    buildInitialSections(initialSections),
+    buildInitialSections([]),
   );
   const [isSaving, setIsSaving] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/apps/platform/src/components/grow/performance-reviews/self-assessment-form.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/self-assessment-form.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import { Button } from "@ascenta/ui/button";
+import { REVIEW_CATEGORY_KEYS } from "@ascenta/db/performance-review-categories";
+import type { ReviewCategoryKey, SelfAssessmentStatus } from "@ascenta/db/performance-review-categories";
+import { ChevronLeft, CheckCircle2, Loader2 } from "lucide-react";
+import { CategorySectionCard } from "./category-section-card";
+
+interface CategorySectionValue {
+  categoryKey: ReviewCategoryKey;
+  rating: number | null;
+  notes: string;
+  examples: string;
+}
+
+interface SelfAssessmentFormProps {
+  reviewId: string;
+  employeeName: string;
+  reviewPeriod: string;
+  initialSections: CategorySectionValue[];
+  initialStatus: SelfAssessmentStatus;
+  accentColor: string;
+  onBack: () => void;
+  onSubmitted: () => void;
+}
+
+function buildInitialSections(initial: CategorySectionValue[]): CategorySectionValue[] {
+  const byKey = new Map<ReviewCategoryKey, CategorySectionValue>();
+  for (const s of initial) {
+    byKey.set(s.categoryKey, s);
+  }
+  return REVIEW_CATEGORY_KEYS.map((key) => {
+    const existing = byKey.get(key);
+    return existing ?? { categoryKey: key, rating: null, notes: "", examples: "" };
+  });
+}
+
+export function SelfAssessmentForm({
+  reviewId,
+  employeeName,
+  reviewPeriod,
+  initialSections,
+  initialStatus,
+  accentColor,
+  onBack,
+  onSubmitted,
+}: SelfAssessmentFormProps) {
+  const [sections, setSections] = useState<CategorySectionValue[]>(() =>
+    buildInitialSections(initialSections),
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(initialStatus === "submitted");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const saveSections = useCallback(
+    async (updatedSections: CategorySectionValue[]) => {
+      setIsSaving(true);
+      try {
+        await fetch(`/api/grow/reviews/${reviewId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ selfAssessment: { sections: updatedSections } }),
+        });
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [reviewId],
+  );
+
+  const handleRatingChange = useCallback(
+    (index: number, rating: number) => {
+      setSections((prev) => {
+        const updated = prev.map((s, i) => (i === index ? { ...s, rating } : s));
+        saveSections(updated);
+        return updated;
+      });
+    },
+    [saveSections],
+  );
+
+  const handleTextChange = useCallback(
+    (index: number, field: "notes" | "examples", value: string) => {
+      setSections((prev) => prev.map((s, i) => (i === index ? { ...s, [field]: value } : s)));
+    },
+    [],
+  );
+
+  const handleBlur = useCallback(
+    (currentSections: CategorySectionValue[]) => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+      debounceRef.current = setTimeout(() => {
+        saveSections(currentSections);
+      }, 500);
+    },
+    [saveSections],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    setIsSubmitting(true);
+    try {
+      await fetch(`/api/grow/reviews/${reviewId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ selfAssessment: { status: "submitted", sections } }),
+      });
+      setSubmitted(true);
+      onSubmitted();
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [reviewId, sections, onSubmitted]);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <button
+            onClick={onBack}
+            className="mt-0.5 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Back
+          </button>
+          <div>
+            <h2 className="text-base font-semibold text-foreground">Self-Assessment</h2>
+            <p className="text-sm text-muted-foreground">
+              {employeeName} · {reviewPeriod}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1.5 text-sm shrink-0">
+          {submitted ? (
+            <>
+              <CheckCircle2 className="h-4 w-4" style={{ color: accentColor }} />
+              <span style={{ color: accentColor }} className="font-medium">
+                Submitted
+              </span>
+            </>
+          ) : isSaving ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              <span className="text-muted-foreground">Saving…</span>
+            </>
+          ) : (
+            <span className="text-muted-foreground">Auto-saving</span>
+          )}
+        </div>
+      </div>
+
+      {/* Category sections */}
+      <div className="space-y-4">
+        {sections.map((section, index) => (
+          <CategorySectionCard
+            key={section.categoryKey}
+            categoryKey={section.categoryKey}
+            index={index + 1}
+            rating={section.rating}
+            notes={section.notes}
+            examples={section.examples}
+            disabled={submitted}
+            onRatingChange={(rating) => handleRatingChange(index, rating)}
+            onNotesChange={(value) => handleTextChange(index, "notes", value)}
+            onExamplesChange={(value) => handleTextChange(index, "examples", value)}
+            onBlur={() => handleBlur(sections)}
+          />
+        ))}
+      </div>
+
+      {/* Submit row */}
+      {!submitted && (
+        <div className="flex justify-end pt-2">
+          <Button
+            onClick={handleSubmit}
+            disabled={isSubmitting}
+            className="text-white"
+            style={{ backgroundColor: accentColor }}
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Submitting…
+              </>
+            ) : (
+              "Submit Self-Assessment"
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/platform/src/components/grow/performance-reviews/self-assessment-form.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/self-assessment-form.tsx
@@ -66,7 +66,11 @@ export function SelfAssessmentForm({
     async function loadSections() {
       try {
         const res = await fetch(`/api/grow/reviews/${reviewId}`);
-        if (!res.ok || cancelled) return;
+        if (!res.ok) {
+          if (!cancelled) setSaveError("Could not load saved progress. Your changes will still be saved.");
+          return;
+        }
+        if (cancelled) return;
 
         const data = await res.json();
         const fetchedSections: CategorySectionValue[] =
@@ -173,7 +177,7 @@ export function SelfAssessmentForm({
       const res = await fetch(`/api/grow/reviews/${reviewId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ selfAssessment: { status: "submitted", sections } }),
+        body: JSON.stringify({ selfAssessment: { status: "submitted", sections: sectionsRef.current } }),
       });
 
       // Medium fix A: surface submit errors
@@ -187,7 +191,7 @@ export function SelfAssessmentForm({
     } finally {
       setIsSubmitting(false);
     }
-  }, [reviewId, sections, onSubmitted]);
+  }, [reviewId, onSubmitted]);
 
   return (
     <div className="space-y-6">

--- a/apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx
@@ -87,7 +87,6 @@ export function SelfAssessmentPanel({
         reviewId={activeReview.id}
         employeeName={activeReview.employeeName}
         reviewPeriod={activeReview.reviewPeriod}
-        initialSections={[]}
         initialStatus={activeReview.selfAssessmentStatus}
         accentColor={accentColor}
         onBack={() => setActiveReviewId(null)}

--- a/apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx
@@ -118,7 +118,7 @@ export function SelfAssessmentPanel({
           </div>
         ) : (
           reviews.map((review) => {
-            const config = STATUS_CONFIG[review.selfAssessmentStatus];
+            const config = STATUS_CONFIG[review.selfAssessmentStatus] ?? STATUS_CONFIG["not_started"];
             const Icon = config.icon;
             return (
               <div key={review.id} className="flex items-center gap-3 px-4 py-3">

--- a/apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { cn } from "@ascenta/ui";
+import { Clock, CheckCircle, FileX, ChevronRight } from "lucide-react";
+import { Button } from "@ascenta/ui/button";
+import type { ComponentType } from "react";
+import type { SelfAssessmentStatus } from "@ascenta/db/performance-review-categories";
+import { SelfAssessmentForm } from "./self-assessment-form";
+
+interface ReviewSummary {
+  id: string;
+  employeeName: string;
+  reviewPeriod: string;
+  reviewType: string;
+  selfAssessmentStatus: SelfAssessmentStatus;
+}
+
+interface SelfAssessmentPanelProps {
+  employeeObjectId: string;
+  employeeName: string;
+  accentColor: string;
+}
+
+const STATUS_CONFIG: Record<
+  SelfAssessmentStatus,
+  {
+    label: string;
+    bg: string;
+    text: string;
+    icon: ComponentType<{ className?: string }>;
+  }
+> = {
+  not_started: {
+    label: "Not Started",
+    bg: "bg-orange-500/15",
+    text: "text-orange-500",
+    icon: FileX,
+  },
+  in_progress: {
+    label: "In Progress",
+    bg: "bg-teal-500/15",
+    text: "text-teal-600",
+    icon: Clock,
+  },
+  submitted: {
+    label: "Submitted",
+    bg: "bg-blue-500/15",
+    text: "text-blue-600",
+    icon: CheckCircle,
+  },
+};
+
+export function SelfAssessmentPanel({
+  employeeObjectId,
+  employeeName,
+  accentColor,
+}: SelfAssessmentPanelProps) {
+  const [reviews, setReviews] = useState<ReviewSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [activeReviewId, setActiveReviewId] = useState<string | null>(null);
+
+  const fetchReviews = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await fetch(
+        `/api/grow/reviews?employeeObjectId=${employeeObjectId}`,
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setReviews(data.reviews ?? []);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [employeeObjectId]);
+
+  useEffect(() => {
+    if (employeeObjectId) fetchReviews();
+  }, [employeeObjectId, fetchReviews]);
+
+  const activeReview = reviews.find((r) => r.id === activeReviewId) ?? null;
+
+  if (activeReview) {
+    return (
+      <SelfAssessmentForm
+        reviewId={activeReview.id}
+        employeeName={activeReview.employeeName}
+        reviewPeriod={activeReview.reviewPeriod}
+        initialSections={[]}
+        initialStatus={activeReview.selfAssessmentStatus}
+        accentColor={accentColor}
+        onBack={() => setActiveReviewId(null)}
+        onSubmitted={() => {
+          fetchReviews();
+          setActiveReviewId(null);
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold">My Performance Reviews</h2>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          Complete your self-assessment before the manager review begins.
+        </p>
+      </div>
+
+      <div className="divide-y rounded-lg border">
+        {isLoading ? (
+          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+            Loading reviews…
+          </div>
+        ) : reviews.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+            No reviews assigned yet.
+          </div>
+        ) : (
+          reviews.map((review) => {
+            const config = STATUS_CONFIG[review.selfAssessmentStatus];
+            const Icon = config.icon;
+            return (
+              <div key={review.id} className="flex items-center gap-3 px-4 py-3">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">
+                    {review.reviewPeriod}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {review.reviewType.replace("_", " ")}
+                  </p>
+                </div>
+                <span
+                  className={cn(
+                    "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium",
+                    config.bg,
+                    config.text,
+                  )}
+                >
+                  <Icon className="h-3 w-3" />
+                  {config.label}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 shrink-0 px-2 text-xs"
+                  style={{ color: accentColor }}
+                  onClick={() => setActiveReviewId(review.id)}
+                >
+                  {review.selfAssessmentStatus === "not_started"
+                    ? "Start"
+                    : review.selfAssessmentStatus === "in_progress"
+                      ? "Continue"
+                      : "View"}
+                  <ChevronRight className="ml-0.5 h-3 w-3" />
+                </Button>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx
@@ -64,7 +64,7 @@ export function SelfAssessmentPanel({
     setIsLoading(true);
     try {
       const res = await fetch(
-        `/api/grow/reviews?employeeObjectId=${employeeObjectId}`,
+        `/api/grow/reviews?employeeObjectId=${encodeURIComponent(employeeObjectId)}`,
       );
       if (res.ok) {
         const data = await res.json();
@@ -128,7 +128,7 @@ export function SelfAssessmentPanel({
                     {review.reviewPeriod}
                   </p>
                   <p className="text-xs text-muted-foreground">
-                    {review.reviewType.replace("_", " ")}
+                    {review.reviewType.replaceAll("_", " ")}
                   </p>
                 </div>
                 <span

--- a/docs/superpowers/plans/2026-04-13-perf-reviews-v2-phase-b-self-assessment.md
+++ b/docs/superpowers/plans/2026-04-13-perf-reviews-v2-phase-b-self-assessment.md
@@ -1,0 +1,651 @@
+# Performance Reviews v2 — Phase B: Self-Assessment UI Implementation Plan
+
+**Date:** 2026-04-13
+**Branch:** `feat/perf-reviews-v2-phase-b`
+**Worktree:** `.worktrees/feat/perf-reviews-v2-phase-b`
+**Spec:** `docs/superpowers/specs/2026-04-13-perf-reviews-v2-phase-b-self-assessment-design.md`
+
+---
+
+## Context
+
+Phase A shipped the data layer (ReviewCycle schema, expanded PerformanceReview with selfAssessment/managerAssessment subdocs, PATCH gate, status machine). Phase B adds the employee-facing self-assessment UI.
+
+Key imports available from Phase A:
+- `REVIEW_CATEGORIES`, `REVIEW_CATEGORY_KEYS`, `RATING_SCALE`, `SELF_ASSESSMENT_STATUSES` from `@ascenta/db/performance-review-categories`
+- `ReviewCategoryKey`, `SelfAssessmentStatus` types from same
+- `selfAssessmentUpdateSchema`, `categorySectionSchema` in `@/lib/validations/performance-review`
+- `LikertScale` component at `@/components/grow/check-in/likert-scale.tsx`
+- `useAuth()` from `@/lib/auth/auth-context` — provides `user.role`, `user.id`, `user.name`
+
+---
+
+## Tasks
+
+### Task 1: `CategorySectionCard` component
+
+**File:** Create `apps/platform/src/components/grow/performance-reviews/category-section-card.tsx`
+
+This is a pure presentational component — no API calls, no state.
+
+```typescript
+"use client";
+
+import { Textarea } from "@ascenta/ui/textarea";
+import { Label } from "@ascenta/ui/label";
+import { cn } from "@ascenta/ui";
+import { REVIEW_CATEGORIES, RATING_SCALE } from "@ascenta/db/performance-review-categories";
+import type { ReviewCategoryKey } from "@ascenta/db/performance-review-categories";
+import { LikertScale } from "@/components/grow/check-in/likert-scale";
+
+interface CategorySectionCardProps {
+  categoryKey: ReviewCategoryKey;
+  index: number;
+  rating: number | null;
+  notes: string;
+  examples: string;
+  disabled?: boolean;
+  onRatingChange: (rating: number) => void;
+  onNotesChange: (notes: string) => void;
+  onExamplesChange: (examples: string) => void;
+  onBlur?: () => void;
+}
+
+export function CategorySectionCard({
+  categoryKey,
+  index,
+  rating,
+  notes,
+  examples,
+  disabled = false,
+  onRatingChange,
+  onNotesChange,
+  onExamplesChange,
+  onBlur,
+}: CategorySectionCardProps) {
+  const category = REVIEW_CATEGORIES[categoryKey];
+
+  return (
+    <div className="rounded-lg border bg-card p-4 space-y-4">
+      {/* Header */}
+      <div>
+        <div className="flex items-start justify-between gap-2">
+          <h3 className="text-sm font-semibold">
+            <span className="text-muted-foreground mr-1.5">{index}.</span>
+            {category.label}
+          </h3>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
+          {category.definition}
+        </p>
+      </div>
+
+      {/* Guided Prompts */}
+      <div className="space-y-1">
+        {category.guidedPrompts.map((prompt, i) => (
+          <p key={i} className="text-xs text-muted-foreground italic">
+            • {prompt}
+          </p>
+        ))}
+      </div>
+
+      {/* Rating */}
+      <div className="space-y-2">
+        <Label className="text-xs font-medium">Rating</Label>
+        <LikertScale
+          value={rating}
+          onChange={onRatingChange}
+          lowLabel={RATING_SCALE[1].label}
+          highLabel={RATING_SCALE[5].label}
+          disabled={disabled}
+        />
+        {rating !== null && (
+          <p className="text-xs text-muted-foreground text-center">
+            {RATING_SCALE[rating as keyof typeof RATING_SCALE]?.label} —{" "}
+            {RATING_SCALE[rating as keyof typeof RATING_SCALE]?.description}
+          </p>
+        )}
+      </div>
+
+      {/* Notes */}
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium">Notes</Label>
+        <Textarea
+          value={notes}
+          onChange={(e) => onNotesChange(e.target.value)}
+          onBlur={onBlur}
+          disabled={disabled}
+          placeholder="Describe your performance in this area during the review period..."
+          className="text-sm resize-none min-h-[80px]"
+        />
+      </div>
+
+      {/* Examples */}
+      <div className="space-y-1.5">
+        <Label className="text-xs font-medium">Specific Examples</Label>
+        <Textarea
+          value={examples}
+          onChange={(e) => onExamplesChange(e.target.value)}
+          onBlur={onBlur}
+          disabled={disabled}
+          placeholder="List specific examples, achievements, or situations from the review period..."
+          className="text-sm resize-none min-h-[80px]"
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 1: Write** the file above.
+
+**Step 2: Verify types**
+```bash
+pnpm -F @ascenta/platform exec tsc --noEmit 2>&1 | grep "error TS" | grep -v "chat-message"
+```
+
+**Step 3: Commit**
+```bash
+git add apps/platform/src/components/grow/performance-reviews/category-section-card.tsx
+git commit -m "feat(ui): add CategorySectionCard for self-assessment per-category entry"
+```
+
+---
+
+### Task 2: `SelfAssessmentForm` component
+
+**File:** Create `apps/platform/src/components/grow/performance-reviews/self-assessment-form.tsx`
+
+This component manages the 10-category form state and handles auto-save + submit.
+
+```typescript
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import { Button } from "@ascenta/ui/button";
+import { REVIEW_CATEGORY_KEYS } from "@ascenta/db/performance-review-categories";
+import type { ReviewCategoryKey, SelfAssessmentStatus } from "@ascenta/db/performance-review-categories";
+import { ChevronLeft, CheckCircle2, Loader2 } from "lucide-react";
+import { CategorySectionCard } from "./category-section-card";
+
+interface CategorySectionValue {
+  categoryKey: ReviewCategoryKey;
+  rating: number | null;
+  notes: string;
+  examples: string;
+}
+
+interface SelfAssessmentFormProps {
+  reviewId: string;
+  employeeName: string;
+  reviewPeriod: string;
+  initialSections: CategorySectionValue[];
+  initialStatus: SelfAssessmentStatus;
+  accentColor: string;
+  onBack: () => void;
+  onSubmitted: () => void;
+}
+
+function buildInitialSections(initial: CategorySectionValue[]): CategorySectionValue[] {
+  return REVIEW_CATEGORY_KEYS.map((key) => {
+    const existing = initial.find((s) => s.categoryKey === key);
+    return existing ?? { categoryKey: key, rating: null, notes: "", examples: "" };
+  });
+}
+
+export function SelfAssessmentForm({
+  reviewId,
+  employeeName,
+  reviewPeriod,
+  initialSections,
+  initialStatus,
+  accentColor,
+  onBack,
+  onSubmitted,
+}: SelfAssessmentFormProps) {
+  const [sections, setSections] = useState<CategorySectionValue[]>(
+    () => buildInitialSections(initialSections),
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(initialStatus === "submitted");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const saveSections = useCallback(
+    async (updatedSections: CategorySectionValue[]) => {
+      setIsSaving(true);
+      try {
+        await fetch(`/api/grow/reviews/${reviewId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            selfAssessment: { sections: updatedSections },
+          }),
+        });
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [reviewId],
+  );
+
+  const handleRatingChange = useCallback(
+    (index: number, rating: number) => {
+      setSections((prev) => {
+        const next = prev.map((s, i) => (i === index ? { ...s, rating } : s));
+        saveSections(next);
+        return next;
+      });
+    },
+    [saveSections],
+  );
+
+  const handleTextChange = useCallback(
+    (index: number, field: "notes" | "examples", value: string) => {
+      setSections((prev) =>
+        prev.map((s, i) => (i === index ? { ...s, [field]: value } : s)),
+      );
+    },
+    [],
+  );
+
+  const handleBlur = useCallback(
+    (currentSections: CategorySectionValue[]) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        saveSections(currentSections);
+      }, 500);
+    },
+    [saveSections],
+  );
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true);
+    try {
+      const res = await fetch(`/api/grow/reviews/${reviewId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          selfAssessment: { status: "submitted", sections },
+        }),
+      });
+      if (res.ok) {
+        setSubmitted(true);
+        onSubmitted();
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="sm" onClick={onBack} className="h-7 px-2">
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <div className="flex-1">
+          <h2 className="text-sm font-semibold">Self-Assessment</h2>
+          <p className="text-xs text-muted-foreground">
+            {employeeName} · {reviewPeriod}
+          </p>
+        </div>
+        {submitted ? (
+          <div className="flex items-center gap-1.5 text-xs font-medium" style={{ color: accentColor }}>
+            <CheckCircle2 className="h-4 w-4" />
+            Submitted
+          </div>
+        ) : isSaving ? (
+          <span className="text-xs text-muted-foreground flex items-center gap-1">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Saving…
+          </span>
+        ) : (
+          <span className="text-xs text-muted-foreground">Auto-saving</span>
+        )}
+      </div>
+
+      {/* Category cards */}
+      <div className="space-y-3">
+        {sections.map((section, index) => (
+          <CategorySectionCard
+            key={section.categoryKey}
+            categoryKey={section.categoryKey}
+            index={index + 1}
+            rating={section.rating}
+            notes={section.notes}
+            examples={section.examples}
+            disabled={submitted}
+            onRatingChange={(rating) => handleRatingChange(index, rating)}
+            onNotesChange={(value) => handleTextChange(index, "notes", value)}
+            onExamplesChange={(value) => handleTextChange(index, "examples", value)}
+            onBlur={() => handleBlur(sections)}
+          />
+        ))}
+      </div>
+
+      {/* Submit */}
+      {!submitted && (
+        <div className="flex justify-end border-t pt-4">
+          <Button
+            onClick={handleSubmit}
+            disabled={isSubmitting}
+            style={{ backgroundColor: accentColor }}
+            className="text-white"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Submitting…
+              </>
+            ) : (
+              "Submit Self-Assessment"
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+**Step 1: Write** the file above.
+
+**Step 2: Verify types**
+```bash
+pnpm -F @ascenta/platform exec tsc --noEmit 2>&1 | grep "error TS" | grep -v "chat-message"
+```
+
+**Step 3: Commit**
+```bash
+git add apps/platform/src/components/grow/performance-reviews/self-assessment-form.tsx
+git commit -m "feat(ui): add SelfAssessmentForm with auto-save and submission"
+```
+
+---
+
+### Task 3: GET /api/grow/reviews — add employeeObjectId filter
+
+**File:** Modify `apps/platform/src/app/api/grow/reviews/route.ts`
+
+Add a new branch at the top of the GET handler, before the existing `managerId` logic:
+
+```typescript
+const employeeObjectId = searchParams.get("employeeObjectId");
+
+if (employeeObjectId) {
+  // Employee view: fetch reviews assigned to this employee
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const employeeReviews = await PerformanceReview.find({ employee: employeeObjectId })
+    .sort({ "reviewPeriod.end": -1 })
+    .lean() as any[];
+
+  return NextResponse.json({
+    success: true,
+    reviews: employeeReviews.map((r) => ({
+      id: String(r._id),
+      employeeName: r.employeeName,
+      reviewPeriod: r.reviewPeriod?.label ?? String(r.reviewPeriod),
+      reviewType: r.reviewType ?? "custom",
+      selfAssessmentStatus: r.selfAssessment?.status ?? "not_started",
+    })),
+  });
+}
+```
+
+Place this block immediately after `await connectDB()` and before the `managerId` check. The existing `managerId` path is unchanged.
+
+Also update the error message for missing params:
+```typescript
+if (!managerId) {
+  return NextResponse.json(
+    { success: false, error: "managerId or employeeObjectId is required" },
+    { status: 400 },
+  );
+}
+```
+
+**Step 1: Read** the current file to find the exact insertion point.
+**Step 2: Edit** to add the employeeObjectId branch.
+**Step 3: Verify types**
+```bash
+pnpm -F @ascenta/platform exec tsc --noEmit 2>&1 | grep "error TS" | grep -v "chat-message"
+```
+**Step 4: Commit**
+```bash
+git add apps/platform/src/app/api/grow/reviews/route.ts
+git commit -m "feat(api): add employeeObjectId filter to GET /api/grow/reviews"
+```
+
+---
+
+### Task 4: `SelfAssessmentPanel` component
+
+**File:** Create `apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx`
+
+```typescript
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { cn } from "@ascenta/ui";
+import { Clock, CheckCircle, FileX, ChevronRight } from "lucide-react";
+import { Button } from "@ascenta/ui/button";
+import type { SelfAssessmentStatus } from "@ascenta/db/performance-review-categories";
+import { SelfAssessmentForm } from "./self-assessment-form";
+
+interface ReviewSummary {
+  id: string;
+  employeeName: string;
+  reviewPeriod: string;
+  reviewType: string;
+  selfAssessmentStatus: SelfAssessmentStatus;
+}
+
+interface SelfAssessmentPanelProps {
+  employeeObjectId: string;
+  employeeName: string;
+  accentColor: string;
+}
+
+const STATUS_CONFIG: Record<SelfAssessmentStatus, { label: string; bg: string; text: string; icon: React.ComponentType<{ className?: string }> }> = {
+  not_started: { label: "Not Started", bg: "bg-orange-500/15", text: "text-orange-500", icon: FileX },
+  in_progress: { label: "In Progress", bg: "bg-teal-500/15", text: "text-teal-600", icon: Clock },
+  submitted: { label: "Submitted", bg: "bg-blue-500/15", text: "text-blue-600", icon: CheckCircle },
+};
+
+export function SelfAssessmentPanel({
+  employeeObjectId,
+  employeeName,
+  accentColor,
+}: SelfAssessmentPanelProps) {
+  const [reviews, setReviews] = useState<ReviewSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [activeReviewId, setActiveReviewId] = useState<string | null>(null);
+
+  const fetchReviews = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/grow/reviews?employeeObjectId=${employeeObjectId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setReviews(data.reviews ?? []);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [employeeObjectId]);
+
+  useEffect(() => {
+    if (employeeObjectId) fetchReviews();
+  }, [employeeObjectId, fetchReviews]);
+
+  const activeReview = reviews.find((r) => r.id === activeReviewId) ?? null;
+
+  if (activeReview) {
+    return (
+      <SelfAssessmentForm
+        reviewId={activeReview.id}
+        employeeName={activeReview.employeeName}
+        reviewPeriod={activeReview.reviewPeriod}
+        initialSections={[]}
+        initialStatus={activeReview.selfAssessmentStatus}
+        accentColor={accentColor}
+        onBack={() => setActiveReviewId(null)}
+        onSubmitted={() => {
+          fetchReviews();
+          setActiveReviewId(null);
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold">My Performance Reviews</h2>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Complete your self-assessment before the manager review begins.
+        </p>
+      </div>
+
+      <div className="rounded-lg border divide-y">
+        {isLoading ? (
+          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+            Loading reviews…
+          </div>
+        ) : reviews.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+            No reviews assigned yet.
+          </div>
+        ) : (
+          reviews.map((review) => {
+            const config = STATUS_CONFIG[review.selfAssessmentStatus];
+            const Icon = config.icon;
+            const canEdit = review.selfAssessmentStatus !== "submitted";
+            return (
+              <div key={review.id} className="flex items-center gap-3 px-4 py-3">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">{review.reviewPeriod}</p>
+                  <p className="text-xs text-muted-foreground">{review.reviewType.replace("_", " ")}</p>
+                </div>
+                <span className={cn("inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium", config.bg, config.text)}>
+                  <Icon className="h-3 w-3" />
+                  {config.label}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs shrink-0"
+                  style={{ color: accentColor }}
+                  onClick={() => setActiveReviewId(review.id)}
+                >
+                  {review.selfAssessmentStatus === "not_started"
+                    ? "Start"
+                    : review.selfAssessmentStatus === "in_progress"
+                    ? "Continue"
+                    : "View"}
+                  <ChevronRight className="ml-0.5 h-3 w-3" />
+                </Button>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 1: Write** the file above.
+
+**Step 2: Verify types**
+```bash
+pnpm -F @ascenta/platform exec tsc --noEmit 2>&1 | grep "error TS" | grep -v "chat-message"
+```
+
+**Step 3: Commit**
+```bash
+git add apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx
+git commit -m "feat(ui): add SelfAssessmentPanel — employee review list with status badges"
+```
+
+---
+
+### Task 5: Wire into page — role-based rendering
+
+**File:** Modify `apps/platform/src/app/[category]/[sub]/page.tsx`
+
+Read the file first. Find where `<ReviewsPanel>` is rendered (currently around line 61–80, inside `pageKey === "grow/performance"`).
+
+Change the rendering logic to:
+
+```typescript
+// In the grow/performance branch, replace <ReviewsPanel ... /> with:
+{user?.role === "employee" ? (
+  <SelfAssessmentPanel
+    employeeObjectId={user.id}
+    employeeName={user.name}
+    accentColor={pageConfig?.accentColor ?? "#44aa99"}
+  />
+) : (
+  <ReviewsPanel
+    pageKey={pageKey}
+    accentColor={pageConfig?.accentColor ?? "#44aa99"}
+    onSwitchToDoTab={onSwitchToDoTab}
+  />
+)}
+```
+
+Add import at the top:
+```typescript
+import { SelfAssessmentPanel } from "@/components/grow/performance-reviews/self-assessment-panel";
+```
+
+**Important**: Read the page.tsx carefully before editing — the exact shape of the existing conditional and variable names may differ. Match the surrounding code style.
+
+**Step 1: Read** `apps/platform/src/app/[category]/[sub]/page.tsx` to find exact insertion point.
+**Step 2: Edit** to add role-based rendering.
+**Step 3: Verify types**
+```bash
+pnpm -F @ascenta/platform exec tsc --noEmit 2>&1 | grep "error TS" | grep -v "chat-message"
+```
+**Step 4: Run tests**
+```bash
+pnpm -F @ascenta/platform run test 2>&1 | tail -10
+```
+**Step 5: Commit**
+```bash
+git add apps/platform/src/app/[category]/[sub]/page.tsx
+git commit -m "feat(ui): render SelfAssessmentPanel for employee role on performance page"
+```
+
+---
+
+### Task 6: Final verification
+
+**Step 1: Run full test suite**
+```bash
+pnpm -F @ascenta/platform run test 2>&1 | tail -15
+```
+Expected: all tests pass.
+
+**Step 2: Type check**
+```bash
+pnpm -F @ascenta/platform exec tsc --noEmit 2>&1 | grep "error TS" | grep -v "chat-message"
+```
+Expected: no new errors.
+
+**Step 3: Self-review acceptance criteria**
+- [ ] `CategorySectionCard` renders all 10 categories with LikertScale + notes + examples
+- [ ] `SelfAssessmentForm` auto-saves on rating change and text blur
+- [ ] `SelfAssessmentForm` submits status `"submitted"` on button click
+- [ ] `SelfAssessmentPanel` fetches from `GET /api/grow/reviews?employeeObjectId=X`
+- [ ] Panel shows list → form → back to list flow
+- [ ] Page renders `SelfAssessmentPanel` for employee role, `ReviewsPanel` for manager/hr
+- [ ] All TypeScript clean (excluding pre-existing chat-message.tsx TS1501)
+
+**Step 4: Commit if any cleanup needed, then push**
+```bash
+git push -u origin feat/perf-reviews-v2-phase-b
+```

--- a/docs/superpowers/specs/2026-04-13-perf-reviews-v2-phase-b-self-assessment-design.md
+++ b/docs/superpowers/specs/2026-04-13-perf-reviews-v2-phase-b-self-assessment-design.md
@@ -1,0 +1,177 @@
+# Performance Reviews v2 — Phase B: Employee Self-Assessment UI Design Spec
+
+**Date:** 2026-04-13
+**Status:** Draft
+**Builds on:** Phase A (86fea34) — schema, constants, API routes
+**Next phases:** Phase C (Manager assessment UI), Phase D (Reflect + Ack), Phase E (Dev plan)
+
+---
+
+## Context
+
+Phase A added the data layer. Phase B surfaces it to employees — a form where they rate themselves across all 10 competency categories, add notes and examples, and submit before the manager can begin their own assessment.
+
+The existing `ReviewsPanel` is manager-facing. Phase B adds a parallel employee-facing surface on the same `/grow/performance` page, gated by `user.role`.
+
+---
+
+## Design
+
+### Role-based rendering on `/grow/performance`
+
+The performance page currently renders `<ReviewsPanel>` unconditionally. Phase B adds conditional rendering:
+
+- `user.role === "employee"` → show `<SelfAssessmentPanel>` (new)
+- `user.role === "manager"` or `"hr"` → show existing `<ReviewsPanel>` (unchanged)
+
+This is a single `if/else` in the page component — no shared component changes needed.
+
+### SelfAssessmentPanel
+
+New component: `apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx`
+
+Responsibilities:
+- Fetches reviews assigned to the current employee via `GET /api/grow/reviews?employeeObjectId={user.id}`
+- Shows a list of reviews with status badges (self-assessment status, not overall status)
+- "Start" / "Continue" button per review opens the inline `SelfAssessmentForm` (replaces list view)
+- Back button returns to the list
+
+State:
+```typescript
+type PanelView = "list" | "form";
+const [view, setPanelView] = useState<PanelView>("list");
+const [activeReviewId, setActiveReviewId] = useState<string | null>(null);
+```
+
+Status badge mapping for self-assessment status:
+- `not_started` → orange "Not Started"
+- `in_progress` → teal "In Progress"
+- `submitted` → blue "Submitted" (read-only, no action button)
+
+### SelfAssessmentForm
+
+New component: `apps/platform/src/components/grow/performance-reviews/self-assessment-form.tsx`
+
+Props:
+```typescript
+interface SelfAssessmentFormProps {
+  reviewId: string;
+  employeeName: string;
+  reviewPeriod: string;
+  initialSections: CategorySectionValue[];
+  initialStatus: SelfAssessmentStatus;
+  accentColor: string;
+  onBack: () => void;
+  onSubmitted: () => void;
+}
+
+interface CategorySectionValue {
+  categoryKey: ReviewCategoryKey;
+  rating: number | null;
+  notes: string;
+  examples: string;
+}
+```
+
+**No react-hook-form** — the 10-category structure is better managed with plain `useState` (array of section values indexed by category key). react-hook-form's `useFieldArray` adds complexity without benefit here since sections are a fixed, known set.
+
+**Auto-save behavior:**
+- On `rating` change: immediate PATCH `selfAssessment.sections` (status auto-advances to `in_progress` via `deriveReviewStatus` if currently `not_started`)
+- On text field blur: PATCH `selfAssessment.sections`
+- Debounce: 500ms for text fields only
+- No explicit "save" button — saving is automatic
+
+**Submit behavior:**
+- "Submit Self-Assessment" button at the bottom
+- PATCH `{ selfAssessment: { status: "submitted" } }`
+- On success: call `onSubmitted()` → panel returns to list view with updated status
+
+**Read-only when submitted:**
+- If `initialStatus === "submitted"`, all fields are disabled, submit button replaced by "Submitted ✓" badge
+
+**Layout — `CategorySectionCard` sub-component:**
+
+New component: `apps/platform/src/components/grow/performance-reviews/category-section-card.tsx`
+
+Per category:
+```
+┌─────────────────────────────────────────────────────┐
+│ [Number] Category Label                   [Required] │
+│ Definition text (muted, smaller)                     │
+├─────────────────────────────────────────────────────┤
+│ Guided prompts (italicized, muted)                   │
+│ • "Does the employee..."                             │
+├─────────────────────────────────────────────────────┤
+│ Rating                                               │
+│ [Improvement Needed] [1] [2] [3] [4] [5] [Exceptional] │
+│ (reuses LikertScale — low/high labels from RATING_SCALE)│
+├─────────────────────────────────────────────────────┤
+│ Notes (textarea, placeholder: "Describe your...")    │
+│ Examples (textarea, placeholder: "Specific examples")│
+└─────────────────────────────────────────────────────┘
+```
+
+Uses `LikertScale` from `@/components/grow/check-in/likert-scale.tsx` with:
+- `lowLabel="Improvement Needed"` (rating 1–2 band)
+- `highLabel="Exceptional"` (rating 5)
+
+All data from `REVIEW_CATEGORIES[key]` — label, definition, guidedPrompts.
+
+### API change: GET /api/grow/reviews — add employeeObjectId filter
+
+Existing route requires `?managerId=X` (employee string ID). Phase B adds:
+- `?employeeObjectId=X` — MongoDB ObjectId string — returns reviews where `employee` field matches
+
+Response shape for employee view (simpler than manager view):
+```json
+{
+  "success": true,
+  "reviews": [
+    {
+      "id": "...",
+      "employeeName": "...",
+      "reviewPeriod": "Q2 2026",
+      "selfAssessmentStatus": "in_progress",
+      "reviewType": "annual"
+    }
+  ]
+}
+```
+
+Note: `managerId` remains required for the manager view; `employeeObjectId` is an alternative path. Both cannot be used together; route returns 400 if neither is provided.
+
+---
+
+## File Map
+
+| Action | File |
+|--------|------|
+| Create | `apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx` |
+| Create | `apps/platform/src/components/grow/performance-reviews/self-assessment-form.tsx` |
+| Create | `apps/platform/src/components/grow/performance-reviews/category-section-card.tsx` |
+| Modify | `apps/platform/src/app/[category]/[sub]/page.tsx` — role-based render |
+| Modify | `apps/platform/src/app/api/grow/reviews/route.ts` — add employeeObjectId filter |
+
+---
+
+## Out of Scope for Phase B
+
+- Evidence linking (goals/check-ins surfaced into sections) — Phase C
+- Manager can-see-employee self-assessment view — Phase C
+- Email notification when self-assessment submitted — Phase F
+- Guided prompt expansion/collapse animation — UX polish
+- Category-level validation requiring all 10 rated before submit — not in reqs; partial submission allowed
+
+---
+
+## Acceptance Criteria
+
+- [ ] Employee role sees `SelfAssessmentPanel`; manager/hr role sees existing `ReviewsPanel`
+- [ ] `GET /api/grow/reviews?employeeObjectId=X` returns reviews assigned to that employee
+- [ ] `SelfAssessmentPanel` lists the employee's reviews with self-assessment status badges
+- [ ] Clicking "Start" / "Continue" opens `SelfAssessmentForm` inline (not modal, not working-doc)
+- [ ] Form shows all 10 categories with LikertScale + notes + examples per category
+- [ ] Rating change auto-saves immediately; text fields auto-save on blur (500ms debounce)
+- [ ] "Submit Self-Assessment" PATCH sets `selfAssessment.status: "submitted"`, panel returns to list
+- [ ] Submitted reviews render in read-only mode
+- [ ] `pnpm test` passes; `tsc --noEmit` no new errors


### PR DESCRIPTION
## Summary

Phase B of Performance Reviews v2 — employee-facing self-assessment form with auto-save, 10 competency categories, and direct inline submission.

- **`CategorySectionCard`**: Pure presentational component rendering one competency category — LikertScale (1–5), guided prompts, notes + examples textareas. Reuses the existing `LikertScale` component from check-ins.
- **`SelfAssessmentForm`**: 10-category form with immediate auto-save on rating change, 500ms debounced save on text blur, submit transitions `selfAssessment.status → "submitted"`. Plain `useState` (no react-hook-form). Read-only when already submitted.
- **`SelfAssessmentPanel`**: List of the employee's assigned reviews with status badges (Not Started / In Progress / Submitted). Switches to `SelfAssessmentForm` inline on click; returns to list after submission.
- **`GET /api/grow/reviews?employeeObjectId=X`**: New branch in the existing reviews route returning a slim `{ id, employeeName, reviewPeriod, reviewType, selfAssessmentStatus }` shape. Existing manager view unchanged.
- **`[category]/[sub]/page.tsx`**: Role-gated render — `user.role === "employee"` gets `SelfAssessmentPanel`; manager/hr get the existing `ReviewsPanel`.

## Test plan

- [x] `pnpm test` — 88/88 tests pass
- [x] `tsc --noEmit` — no new type errors
- [ ] Manual: switch to employee role via user-picker → navigate to Grow / Performance System → Reviews tab → verify self-assessment panel appears
- [ ] Manual: click "Start" on a review → fill out a category rating → confirm auto-save indicator → submit → confirm status badge updates to Submitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)