### PR TITLE
feat: performance reviews v2 Phase C — manager assessment UI

### DIFF
--- a/apps/platform/src/app/api/grow/reviews/route.ts
+++ b/apps/platform/src/app/api/grow/reviews/route.ts
@@ -102,7 +102,7 @@ export async function GET(req: NextRequest) {
       return {
         employeeId: emp.employeeId,
         employeeObjectId: empId,
-        name: `${emp.firstName} ${emp.lastName}`,
+        employeeName: `${emp.firstName} ${emp.lastName}`,
         department: emp.department,
         goalCount: goalCountMap.get(empId) || 0,
         status: review ? review.status : "not_started",

--- a/apps/platform/src/app/api/grow/reviews/route.ts
+++ b/apps/platform/src/app/api/grow/reviews/route.ts
@@ -108,6 +108,8 @@ export async function GET(req: NextRequest) {
         status: review ? review.status : "not_started",
         currentStep: review ? review.currentStep : null,
         reviewId: review ? String(review._id) : null,
+        selfAssessmentStatus: review ? (review.selfAssessment?.status as string | undefined) ?? "not_started" : "not_started",
+        managerAssessmentStatus: review ? (review.managerAssessment?.status as string | undefined) ?? "not_started" : "not_started",
       };
     });
 

--- a/apps/platform/src/components/grow/performance-reviews/category-section-card.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/category-section-card.tsx
@@ -17,6 +17,8 @@ interface CategorySectionCardProps {
   onNotesChange: (notes: string) => void;
   onExamplesChange: (examples: string) => void;
   onBlur?: () => void;
+  employeeRating?: number | null;
+  employeeNotes?: string;
 }
 
 export function CategorySectionCard({
@@ -30,6 +32,8 @@ export function CategorySectionCard({
   onNotesChange,
   onExamplesChange,
   onBlur,
+  employeeRating = undefined,
+  employeeNotes = undefined,
 }: CategorySectionCardProps) {
   const category = REVIEW_CATEGORIES[categoryKey];
 
@@ -42,6 +46,19 @@ export function CategorySectionCard({
         </h3>
         <p className="text-xs text-muted-foreground">{category.definition}</p>
       </div>
+
+      {/* Employee self-assessment reference (manager view only) */}
+      {employeeRating != null && (
+        <div className="rounded-md border border-border bg-muted/30 px-3 py-2.5 space-y-1">
+          <p className="text-xs font-medium text-muted-foreground">Employee's self-assessment</p>
+          <p className="text-xs text-foreground">
+            {employeeRating} — {RATING_SCALE[employeeRating as keyof typeof RATING_SCALE]?.label ?? ""}
+          </p>
+          {employeeNotes && employeeNotes.trim() !== "" && (
+            <p className="text-xs text-muted-foreground line-clamp-3">{employeeNotes}</p>
+          )}
+        </div>
+      )}
 
       {/* Guided prompts */}
       <ul className="space-y-1 pl-4 list-disc">

--- a/apps/platform/src/components/grow/performance-reviews/manager-assessment-form.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/manager-assessment-form.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { Button } from "@ascenta/ui/button";
 import { REVIEW_CATEGORY_KEYS } from "@ascenta/db/performance-review-categories";
-import type { ReviewCategoryKey, SelfAssessmentStatus } from "@ascenta/db/performance-review-categories";
+import type { ReviewCategoryKey, SelfAssessmentStatus, ManagerAssessmentStatus } from "@ascenta/db/performance-review-categories";
 import { ChevronLeft, CheckCircle2, Loader2 } from "lucide-react";
 import { CategorySectionCard } from "./category-section-card";
 
@@ -18,7 +18,7 @@ interface ManagerAssessmentFormProps {
   reviewId: string;
   employeeName: string;
   reviewPeriod: string;
-  initialStatus: SelfAssessmentStatus;
+  initialStatus: ManagerAssessmentStatus;
   accentColor: string;
   onBack: () => void;
   onSubmitted: () => void;
@@ -84,7 +84,7 @@ export function ManagerAssessmentForm({
         // Load manager's assessment sections for editing
         const fetchedManagerSections: CategorySectionValue[] =
           data?.review?.managerAssessment?.sections ?? [];
-        const fetchedManagerStatus: SelfAssessmentStatus =
+        const fetchedManagerStatus: ManagerAssessmentStatus =
           data?.review?.managerAssessment?.status ?? initialStatus;
 
         if (!cancelled) {
@@ -131,7 +131,12 @@ export function ManagerAssessmentForm({
         });
 
         if (!res.ok) {
-          setSaveError("Failed to save — please try again.");
+          const errorData = await res.json().catch(() => ({})) as { error?: string };
+          const message =
+            res.status === 403
+              ? "Self-assessment must be submitted before you can save."
+              : errorData?.error ?? "Failed to save — please try again.";
+          setSaveError(message);
         } else {
           setSaveError(null);
         }
@@ -187,7 +192,12 @@ export function ManagerAssessmentForm({
       });
 
       if (!res.ok) {
-        setSubmitError("Failed to submit — please try again.");
+        const errorData = await res.json().catch(() => ({})) as { error?: string };
+        const message =
+          res.status === 403
+            ? "Self-assessment must be submitted before you can submit your assessment."
+            : errorData?.error ?? "Failed to submit — please try again.";
+        setSubmitError(message);
         return;
       }
 

--- a/apps/platform/src/components/grow/performance-reviews/manager-assessment-form.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/manager-assessment-form.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+import { Button } from "@ascenta/ui/button";
+import { REVIEW_CATEGORY_KEYS } from "@ascenta/db/performance-review-categories";
+import type { ReviewCategoryKey, SelfAssessmentStatus } from "@ascenta/db/performance-review-categories";
+import { ChevronLeft, CheckCircle2, Loader2 } from "lucide-react";
+import { CategorySectionCard } from "./category-section-card";
+
+interface CategorySectionValue {
+  categoryKey: ReviewCategoryKey;
+  rating: number | null;
+  notes: string;
+  examples: string;
+}
+
+interface ManagerAssessmentFormProps {
+  reviewId: string;
+  employeeName: string;
+  reviewPeriod: string;
+  initialStatus: SelfAssessmentStatus;
+  accentColor: string;
+  onBack: () => void;
+  onSubmitted: () => void;
+}
+
+function buildInitialSections(initial: CategorySectionValue[]): CategorySectionValue[] {
+  const byKey = new Map<ReviewCategoryKey, CategorySectionValue>();
+  for (const s of initial) {
+    byKey.set(s.categoryKey, s);
+  }
+  return REVIEW_CATEGORY_KEYS.map((key) => {
+    const existing = byKey.get(key);
+    return existing ?? { categoryKey: key, rating: null, notes: "", examples: "" };
+  });
+}
+
+export function ManagerAssessmentForm({
+  reviewId,
+  employeeName,
+  reviewPeriod,
+  initialStatus,
+  accentColor,
+  onBack,
+  onSubmitted,
+}: ManagerAssessmentFormProps) {
+  const [sections, setSections] = useState<CategorySectionValue[]>(() =>
+    buildInitialSections([]),
+  );
+  const [employeeSections, setEmployeeSections] = useState<CategorySectionValue[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(initialStatus === "submitted");
+  const [isLoadingInitial, setIsLoadingInitial] = useState(true);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sectionsRef = useRef<CategorySectionValue[]>(sections);
+  // Track whether status has already been advanced to "in_progress" so we only
+  // send that field on the very first save for a "not_started" review.
+  const hasFirstSavedRef = useRef(initialStatus !== "not_started");
+
+  const getEmployeeSection = (key: ReviewCategoryKey) =>
+    employeeSections.find((s) => s.categoryKey === key);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSections() {
+      try {
+        const res = await fetch(`/api/grow/reviews/${reviewId}`);
+        if (!res.ok) {
+          if (!cancelled) setSaveError("Could not load saved progress. Your changes will still be saved.");
+          return;
+        }
+        if (cancelled) return;
+
+        const data = await res.json();
+
+        // Load employee's self-assessment sections as read-only reference
+        const fetchedEmployeeSections: CategorySectionValue[] =
+          data?.review?.selfAssessment?.sections ?? [];
+
+        // Load manager's assessment sections for editing
+        const fetchedManagerSections: CategorySectionValue[] =
+          data?.review?.managerAssessment?.sections ?? [];
+        const fetchedManagerStatus: SelfAssessmentStatus =
+          data?.review?.managerAssessment?.status ?? initialStatus;
+
+        if (!cancelled) {
+          setEmployeeSections(fetchedEmployeeSections);
+
+          const built = buildInitialSections(fetchedManagerSections);
+          setSections(built);
+          sectionsRef.current = built;
+
+          if (fetchedManagerStatus === "submitted") {
+            setSubmitted(true);
+          }
+          // If the DB already shows in_progress (or submitted), no need to
+          // advance status again on the first save.
+          if (fetchedManagerStatus !== "not_started") {
+            hasFirstSavedRef.current = true;
+          }
+        }
+      } finally {
+        if (!cancelled) setIsLoadingInitial(false);
+      }
+    }
+
+    loadSections();
+    return () => {
+      cancelled = true;
+    };
+  }, [reviewId, initialStatus]);
+
+  const saveSections = useCallback(
+    async (updatedSections: CategorySectionValue[]) => {
+      setIsSaving(true);
+      try {
+        const body: Record<string, unknown> = { sections: updatedSections };
+        if (!hasFirstSavedRef.current) {
+          hasFirstSavedRef.current = true;
+          body.status = "in_progress";
+        }
+
+        const res = await fetch(`/api/grow/reviews/${reviewId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ managerAssessment: body }),
+        });
+
+        if (!res.ok) {
+          setSaveError("Failed to save — please try again.");
+        } else {
+          setSaveError(null);
+        }
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [reviewId],
+  );
+
+  const handleRatingChange = useCallback(
+    (index: number, rating: number) => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      setSections((prev) => {
+        const updated = prev.map((s, i) => (i === index ? { ...s, rating } : s));
+        sectionsRef.current = updated;
+        saveSections(updated);
+        return updated;
+      });
+    },
+    [saveSections],
+  );
+
+  const handleTextChange = useCallback(
+    (index: number, field: "notes" | "examples", value: string) => {
+      setSections((prev) => {
+        const next = prev.map((s, i) => (i === index ? { ...s, [field]: value } : s));
+        sectionsRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
+
+  const handleBlur = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      saveSections(sectionsRef.current);
+    }, 500);
+  }, [saveSections]);
+
+  const handleSubmit = useCallback(async () => {
+    setIsSubmitting(true);
+    setSubmitError(null);
+    try {
+      const res = await fetch(`/api/grow/reviews/${reviewId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ managerAssessment: { status: "submitted", sections: sectionsRef.current } }),
+      });
+
+      if (!res.ok) {
+        setSubmitError("Failed to submit — please try again.");
+        return;
+      }
+
+      setSubmitted(true);
+      onSubmitted();
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [reviewId, onSubmitted]);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <button
+            onClick={onBack}
+            className="mt-0.5 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Back
+          </button>
+          <div>
+            <h2 className="text-base font-semibold text-foreground">Manager Assessment</h2>
+            <p className="text-sm text-muted-foreground">
+              {employeeName} · {reviewPeriod}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1.5 text-sm shrink-0">
+          {submitted ? (
+            <>
+              <CheckCircle2 className="h-4 w-4" style={{ color: accentColor }} />
+              <span style={{ color: accentColor }} className="font-medium">
+                Submitted
+              </span>
+            </>
+          ) : saveError ? (
+            <span className="text-red-500">{saveError}</span>
+          ) : isSaving ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              <span className="text-muted-foreground">Saving…</span>
+            </>
+          ) : (
+            <span className="text-muted-foreground">Auto-saving</span>
+          )}
+        </div>
+      </div>
+
+      {isLoadingInitial ? (
+        <div className="flex justify-center py-10">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <>
+          {/* Category sections */}
+          <div className="space-y-4">
+            {sections.map((section, index) => {
+              const empSection = getEmployeeSection(section.categoryKey);
+              return (
+                <CategorySectionCard
+                  key={section.categoryKey}
+                  categoryKey={section.categoryKey}
+                  index={index + 1}
+                  rating={section.rating}
+                  notes={section.notes}
+                  examples={section.examples}
+                  disabled={submitted}
+                  onRatingChange={(rating) => handleRatingChange(index, rating)}
+                  onNotesChange={(value) => handleTextChange(index, "notes", value)}
+                  onExamplesChange={(value) => handleTextChange(index, "examples", value)}
+                  onBlur={handleBlur}
+                  employeeRating={empSection?.rating ?? null}
+                  employeeNotes={empSection?.notes ?? ""}
+                />
+              );
+            })}
+          </div>
+
+          {/* Submit row */}
+          {!submitted && (
+            <div className="flex flex-col items-end gap-2 pt-2">
+              {sections.some((s) => s.rating === null) && (
+                <p className="text-xs text-amber-600">
+                  {sections.filter((s) => s.rating === null).length} of 10 categories have no
+                  rating yet.
+                </p>
+              )}
+              {submitError && <p className="text-xs text-red-500">{submitError}</p>}
+              <Button
+                onClick={handleSubmit}
+                disabled={isSubmitting}
+                className="text-white"
+                style={{ backgroundColor: accentColor }}
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Submitting…
+                  </>
+                ) : (
+                  "Submit Manager Assessment"
+                )}
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/platform/src/components/grow/reviews-panel.tsx
+++ b/apps/platform/src/components/grow/reviews-panel.tsx
@@ -307,7 +307,7 @@ export function ReviewsPanel({ pageKey, accentColor, onSwitchToDoTab }: ReviewsP
                         </Button>
                       )}
                       {(review.status === "in_progress" ||
-                        review.status === "draft_complete") && (
+                        review.status === "draft_complete") && review.reviewId && (
                         <Button
                           variant="ghost"
                           size="sm"

--- a/apps/platform/src/components/grow/reviews-panel.tsx
+++ b/apps/platform/src/components/grow/reviews-panel.tsx
@@ -17,16 +17,20 @@ import { cn } from "@ascenta/ui";
 import { useChat } from "@/lib/chat/chat-context";
 import { useAuth } from "@/lib/auth/auth-context";
 import { AlertCircle, Download, Users, Clock, CheckCircle, FileX } from "lucide-react";
+import { ManagerAssessmentForm } from "./performance-reviews/manager-assessment-form";
+import type { ManagerAssessmentStatus } from "@ascenta/db/performance-review-categories";
 
 interface ReviewEntry {
   employeeId: string;
   employeeObjectId: string;
-  name: string;
+  employeeName: string;
   department: string;
   goalCount: number;
   status: string;
   currentStep: string | null;
   reviewId: string | null;
+  selfAssessmentStatus: string;
+  managerAssessmentStatus: string;
 }
 
 interface ReviewAggregates {
@@ -75,7 +79,12 @@ export function ReviewsPanel({ pageKey, accentColor, onSwitchToDoTab }: ReviewsP
   });
   const [period, setPeriod] = useState(getCurrentPeriod());
   const [isLoading, setIsLoading] = useState(true);
+  const [activeAssessmentReviewId, setActiveAssessmentReviewId] = useState<string | null>(null);
   const { sendMessage } = useChat();
+
+  const activeAssessmentReview = activeAssessmentReviewId
+    ? (reviews.find((r) => r.reviewId === activeAssessmentReviewId) ?? null)
+    : null;
 
   const fetchReviews = useCallback(async () => {
     setIsLoading(true);
@@ -130,6 +139,23 @@ export function ReviewsPanel({ pageKey, accentColor, onSwitchToDoTab }: ReviewsP
   };
 
   const dueWithin2Weeks = aggregates.notStarted > 0;
+
+  if (activeAssessmentReview) {
+    return (
+      <ManagerAssessmentForm
+        reviewId={activeAssessmentReview.reviewId!}
+        employeeName={activeAssessmentReview.employeeName}
+        reviewPeriod={period}
+        initialStatus={activeAssessmentReview.managerAssessmentStatus as ManagerAssessmentStatus}
+        accentColor={accentColor}
+        onBack={() => setActiveAssessmentReviewId(null)}
+        onSubmitted={() => {
+          fetchReviews();
+          setActiveAssessmentReviewId(null);
+        }}
+      />
+    );
+  }
 
   return (
     <div className="space-y-4">
@@ -243,7 +269,7 @@ export function ReviewsPanel({ pageKey, accentColor, onSwitchToDoTab }: ReviewsP
                 const colors = STATUS_COLORS[review.status] || STATUS_COLORS.not_started;
                 return (
                   <tr key={review.employeeId} className="border-b last:border-0">
-                    <td className="px-3 py-2.5 font-medium">{review.name}</td>
+                    <td className="px-3 py-2.5 font-medium">{review.employeeName}</td>
                     <td className="px-3 py-2.5 text-muted-foreground">{review.department}</td>
                     <td className="px-3 py-2.5 text-center text-muted-foreground">
                       {review.goalCount}
@@ -275,7 +301,7 @@ export function ReviewsPanel({ pageKey, accentColor, onSwitchToDoTab }: ReviewsP
                           size="sm"
                           className="h-7 text-xs"
                           style={{ color: accentColor }}
-                          onClick={() => handleStartReview(review.name, review.employeeId)}
+                          onClick={() => handleStartReview(review.employeeName, review.employeeId)}
                         >
                           Start Review
                         </Button>
@@ -288,10 +314,32 @@ export function ReviewsPanel({ pageKey, accentColor, onSwitchToDoTab }: ReviewsP
                           className="h-7 text-xs"
                           style={{ color: accentColor }}
                           onClick={() =>
-                            handleContinueReview(review.name, review.reviewId!)
+                            handleContinueReview(review.employeeName, review.reviewId!)
                           }
                         >
                           Continue →
+                        </Button>
+                      )}
+                      {review.status === "self_submitted" && review.reviewId && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 text-xs"
+                          style={{ color: accentColor }}
+                          onClick={() => setActiveAssessmentReviewId(review.reviewId!)}
+                        >
+                          Begin Assessment
+                        </Button>
+                      )}
+                      {review.status === "manager_in_progress" && review.reviewId && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 text-xs"
+                          style={{ color: accentColor }}
+                          onClick={() => setActiveAssessmentReviewId(review.reviewId!)}
+                        >
+                          Continue Assessment →
                         </Button>
                       )}
                       {(review.status === "finalized" || review.status === "shared") && (


### PR DESCRIPTION
## Summary

- Manager can rate employees across all 10 competency categories after the employee has submitted their self-assessment
- Inline `ManagerAssessmentForm` opens within `ReviewsPanel` (same panel-swap pattern as Phase B)
- Employee's self-assessment ratings shown as read-only reference in each category card
- Auto-save on rating change (immediate) and text field blur (500ms debounce), with race-safe `sectionsRef` pattern
- Gate enforced: "Begin Assessment" button only appears when `status === "self_submitted"`; 403 responses surface as meaningful user messages
- Status advances to `manager_in_progress` on first save; "Continue Assessment" restores prior work on re-entry

## Changes

- **API**: `GET /api/grow/reviews?managerId=X` now includes `selfAssessmentStatus` and `managerAssessmentStatus` per entry; response field renamed `name` → `employeeName` for consistency
- **CategorySectionCard**: new optional `employeeRating` + `employeeNotes` props render a read-only employee reference block (only in manager context)
- **ManagerAssessmentForm** (new): mirrors `SelfAssessmentForm` with `managerAssessment` PATCH key, employee section reference display, and `ManagerAssessmentStatus` typing
- **ReviewsPanel**: wires inline swap to `ManagerAssessmentForm` for `self_submitted` / `manager_in_progress` rows

## Test plan

- [ ] As manager: review with `self_submitted` status shows "Begin Assessment" button
- [ ] Clicking opens form inline with employee's self-assessment ratings visible per category
- [ ] Rating change saves immediately; status advances to `manager_in_progress`
- [ ] Navigating Back and clicking "Continue Assessment" restores prior ratings
- [ ] Submit sets `managerAssessment.status: "submitted"`, panel returns to list
- [ ] Submitted manager assessment renders read-only
- [ ] `pnpm test`: 88/88 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)