### PR TITLE
feat: performance reviews v2 Phase D — dev plan, evidence, acknowledgment

### DIFF
--- a/apps/platform/src/app/api/grow/reviews/[id]/evidence/route.ts
+++ b/apps/platform/src/app/api/grow/reviews/[id]/evidence/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from "next/server";
+import { connectDB } from "@ascenta/db";
+import { PerformanceReview } from "@ascenta/db/performance-review-schema";
+import { Goal } from "@ascenta/db/goal-schema";
+import { CheckIn } from "@ascenta/db/checkin-schema";
+import { PerformanceNote } from "@ascenta/db/performance-note-schema";
+
+interface GoalEvidence {
+  id: string;
+  kind: "goal";
+  label: string;
+  category: string;
+  status: string;
+}
+
+interface CheckInEvidence {
+  id: string;
+  kind: "checkin";
+  label: string;
+}
+
+interface NoteEvidence {
+  id: string;
+  kind: "note";
+  label: string;
+}
+
+function formatCheckInLabel(checkin: {
+  participate?: { completedAt?: Date | null };
+}): string {
+  const completedAt = checkin.participate?.completedAt;
+  if (!completedAt) return "Check-in (not completed)";
+  const date = new Date(completedAt);
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const year = date.getFullYear();
+  return `Check-in · ${month}/${day}/${year}`;
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    await connectDB();
+    const { id } = await params;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const review = await PerformanceReview.findById(id).lean() as any;
+    if (!review) {
+      return NextResponse.json(
+        { success: false, error: "Review not found" },
+        { status: 404 },
+      );
+    }
+
+    const employeeObjectId = review.employee;
+    const reviewPeriodStart = review.reviewPeriod?.start;
+    const reviewPeriodEnd = review.reviewPeriod?.end;
+
+    // Fetch goals, check-ins, and notes in parallel
+    const [goals, checkIns, notes] = await Promise.all([
+      Goal.find({
+        owner: employeeObjectId,
+        "timePeriod.end": { $gte: reviewPeriodStart },
+        "timePeriod.start": { $lte: reviewPeriodEnd },
+      })
+        .select("_id objectiveStatement goalType status")
+        .lean(),
+      CheckIn.find({
+        employee: employeeObjectId,
+        scheduledAt: { $gte: reviewPeriodStart, $lte: reviewPeriodEnd },
+      })
+        .select("_id participate")
+        .lean(),
+      PerformanceNote.find({
+        employee: employeeObjectId,
+        createdAt: { $gte: reviewPeriodStart, $lte: reviewPeriodEnd },
+      })
+        .select("_id type observation createdAt")
+        .lean(),
+    ]);
+
+    const goalsEvidence: GoalEvidence[] = goals.map((g: any) => ({
+      id: String(g._id),
+      kind: "goal" as const,
+      label: g.objectiveStatement,
+      category: g.goalType,
+      status: g.status,
+    }));
+
+    const checkInsEvidence: CheckInEvidence[] = checkIns.map((c: any) => ({
+      id: String(c._id),
+      kind: "checkin" as const,
+      label: formatCheckInLabel(c),
+    }));
+
+    const notesEvidence: NoteEvidence[] = notes.map((n: any) => ({
+      id: String(n._id),
+      kind: "note" as const,
+      label: `${n.type}: ${n.observation.slice(0, 60)}${n.observation.length > 60 ? "…" : ""}`,
+    }));
+
+    return NextResponse.json({
+      success: true,
+      goals: goalsEvidence,
+      checkIns: checkInsEvidence,
+      notes: notesEvidence,
+    });
+  } catch (error) {
+    console.error("Error fetching evidence:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch evidence" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/platform/src/app/api/grow/reviews/[id]/evidence/route.ts
+++ b/apps/platform/src/app/api/grow/reviews/[id]/evidence/route.ts
@@ -65,7 +65,7 @@ export async function GET(
         "timePeriod.end": { $gte: reviewPeriodStart },
         "timePeriod.start": { $lte: reviewPeriodEnd },
       })
-        .select("_id objectiveStatement goalType status")
+        .select("_id objectiveStatement goalType title category status")
         .lean(),
       CheckIn.find({
         employee: employeeObjectId,
@@ -84,8 +84,8 @@ export async function GET(
     const goalsEvidence: GoalEvidence[] = goals.map((g: any) => ({
       id: String(g._id),
       kind: "goal" as const,
-      label: g.objectiveStatement,
-      category: g.goalType,
+      label: g.objectiveStatement ?? g.title ?? "Untitled goal",
+      category: g.goalType ?? g.category ?? "goal",
       status: g.status,
     }));
 

--- a/apps/platform/src/app/api/grow/reviews/[id]/route.ts
+++ b/apps/platform/src/app/api/grow/reviews/[id]/route.ts
@@ -89,6 +89,26 @@ export async function PATCH(
       }
     }
 
+    // Status transition gates
+    if (data.status === "finalized") {
+      const devPlanStatus = review.developmentPlan?.status ?? "not_started";
+      if (devPlanStatus !== "finalized") {
+        return NextResponse.json(
+          { success: false, error: "Development plan must be finalized before the review can be finalized." },
+          { status: 422 },
+        );
+      }
+    }
+
+    if (data.status === "acknowledged") {
+      if (review.status !== "finalized") {
+        return NextResponse.json(
+          { success: false, error: "Review must be finalized before it can be acknowledged." },
+          { status: 422 },
+        );
+      }
+    }
+
     // Build $set update ops
     const updateOps: Record<string, unknown> = {};
 

--- a/apps/platform/src/app/api/grow/reviews/[id]/route.ts
+++ b/apps/platform/src/app/api/grow/reviews/[id]/route.ts
@@ -113,7 +113,15 @@ export async function PATCH(
     const updateOps: Record<string, unknown> = {};
 
     // V1 fields
-    if (data.status !== undefined) updateOps.status = data.status;
+    if (data.status !== undefined) {
+      updateOps.status = data.status;
+      if (data.status === "finalized" && !review.finalizedAt) {
+        updateOps.finalizedAt = new Date();
+      }
+      if (data.status === "acknowledged" && !review.acknowledgedAt) {
+        updateOps.acknowledgedAt = new Date();
+      }
+    }
     if (data.currentStep !== undefined) updateOps.currentStep = data.currentStep;
     if (data.goalHandoffCompleted !== undefined) {
       updateOps.goalHandoffCompleted = data.goalHandoffCompleted;

--- a/apps/platform/src/app/api/grow/reviews/route.ts
+++ b/apps/platform/src/app/api/grow/reviews/route.ts
@@ -111,6 +111,7 @@ export async function GET(req: NextRequest) {
         reviewId: review ? String(review._id) : null,
         selfAssessmentStatus: review ? (review.selfAssessment?.status as string | undefined) ?? "not_started" : "not_started",
         managerAssessmentStatus: review ? (review.managerAssessment?.status as string | undefined) ?? "not_started" : "not_started",
+        devPlanStatus: review ? (review.developmentPlan?.status as string | undefined) ?? "not_started" : "not_started",
       };
     });
 

--- a/apps/platform/src/app/api/grow/reviews/route.ts
+++ b/apps/platform/src/app/api/grow/reviews/route.ts
@@ -33,6 +33,7 @@ export async function GET(req: NextRequest) {
             ? r.reviewPeriod
             : (r.reviewPeriod?.label as string | undefined) ?? "",
           reviewType: (r.reviewType as string | undefined) ?? "custom",
+          status: (r.status as string) ?? "not_started",
           selfAssessmentStatus: (r.selfAssessment?.status as string | undefined) ?? "not_started",
         })),
       });

--- a/apps/platform/src/components/grow/performance-reviews/acknowledgment-view.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/acknowledgment-view.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@ascenta/ui/button";
+import {
+  REVIEW_CATEGORY_KEYS,
+  REVIEW_CATEGORIES,
+  RATING_SCALE,
+} from "@ascenta/db/performance-review-categories";
+import type { ReviewCategoryKey } from "@ascenta/db/performance-review-categories";
+import { ChevronLeft, CheckCircle2, Loader2 } from "lucide-react";
+
+interface AssessmentSection {
+  categoryKey: ReviewCategoryKey;
+  rating: number | null;
+  notes: string;
+  examples: string;
+}
+
+interface AreaOfImprovement {
+  area: string;
+  actions: string[];
+  timeline: string;
+  owner: string;
+}
+
+interface DevelopmentPlan {
+  status: string;
+  areasOfImprovement: AreaOfImprovement[];
+  managerCommitments: string[];
+  nextReviewDate: string | null;
+}
+
+interface ReviewData {
+  selfAssessment: { sections: AssessmentSection[] };
+  managerAssessment: { sections: AssessmentSection[] };
+  developmentPlan: DevelopmentPlan | null;
+  status: string;
+}
+
+interface AcknowledgmentViewProps {
+  reviewId: string;
+  employeeName: string;
+  reviewPeriod: string;
+  accentColor: string;
+  onBack: () => void;
+  onAcknowledged: () => void;
+}
+
+function getSectionForKey(
+  sections: AssessmentSection[],
+  key: ReviewCategoryKey,
+): AssessmentSection | undefined {
+  return sections.find((s) => s.categoryKey === key);
+}
+
+export function AcknowledgmentView({
+  reviewId,
+  employeeName,
+  reviewPeriod,
+  accentColor,
+  onBack,
+  onAcknowledged,
+}: AcknowledgmentViewProps) {
+  const [review, setReview] = useState<ReviewData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isAcknowledging, setIsAcknowledging] = useState(false);
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [ackError, setAckError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const res = await fetch(`/api/grow/reviews/${reviewId}`);
+        if (!res.ok) {
+          if (!cancelled) setLoadError("Could not load review data. Please try again.");
+          return;
+        }
+        const data = await res.json();
+        if (!cancelled) {
+          const r = data?.review;
+          setReview({
+            selfAssessment: r?.selfAssessment ?? { sections: [] },
+            managerAssessment: r?.managerAssessment ?? { sections: [] },
+            developmentPlan: r?.developmentPlan ?? null,
+            status: r?.status ?? "",
+          });
+          if (r?.status === "acknowledged") {
+            setAcknowledged(true);
+          }
+        }
+      } catch {
+        if (!cancelled) setLoadError("Failed to load review. Please try again.");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [reviewId]);
+
+  const handleAcknowledge = async () => {
+    setIsAcknowledging(true);
+    setAckError(null);
+    try {
+      const res = await fetch(`/api/grow/reviews/${reviewId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "acknowledged" }),
+      });
+      if (res.ok) {
+        setAcknowledged(true);
+        onAcknowledged();
+      } else {
+        const data = await res.json().catch(() => ({})) as { error?: string };
+        setAckError(data.error ?? "Failed to acknowledge — please try again.");
+      }
+    } finally {
+      setIsAcknowledging(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <button
+            onClick={onBack}
+            className="mt-0.5 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Back
+          </button>
+          <div>
+            <h2 className="text-base font-semibold text-foreground">
+              Performance Review — {reviewPeriod}
+            </h2>
+            <p className="text-sm text-muted-foreground">{employeeName}</p>
+          </div>
+        </div>
+        {acknowledged && (
+          <div
+            className="flex items-center gap-1.5 text-sm shrink-0"
+            style={{ color: accentColor }}
+          >
+            <CheckCircle2 className="h-4 w-4" />
+            <span className="font-medium">Acknowledged</span>
+          </div>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center py-10">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      ) : loadError ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3">
+          <p className="text-sm text-red-600">{loadError}</p>
+        </div>
+      ) : review ? (
+        <>
+          {/* Column headers */}
+          <div className="grid grid-cols-2 gap-4">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+              Your Self-Assessment
+            </p>
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+              Manager&apos;s Assessment
+            </p>
+          </div>
+
+          {/* Category comparison rows */}
+          <div className="space-y-4">
+            {REVIEW_CATEGORY_KEYS.map((key, i) => {
+              const category = REVIEW_CATEGORIES[key];
+              const selfSection = getSectionForKey(
+                review.selfAssessment.sections,
+                key,
+              );
+              const mgrSection = getSectionForKey(
+                review.managerAssessment.sections,
+                key,
+              );
+              const selfRating = selfSection?.rating ?? null;
+              const mgrRating = mgrSection?.rating ?? null;
+              const selfNotes = selfSection?.notes ?? "";
+              const mgrNotes = mgrSection?.notes ?? "";
+
+              return (
+                <div
+                  key={key}
+                  className="rounded-lg border border-border bg-card overflow-hidden"
+                >
+                  <div className="bg-muted/40 px-4 py-2 border-b border-border">
+                    <p className="text-xs font-semibold text-foreground">
+                      {i + 1}. {category.label}
+                    </p>
+                  </div>
+                  <div className="grid grid-cols-2 gap-0 divide-x divide-border">
+                    {/* Self-assessment column */}
+                    <div className="p-4 space-y-1.5">
+                      <p className="text-xs font-medium text-muted-foreground">Self-Assessment</p>
+                      <p className="text-sm">
+                        {selfRating != null
+                          ? `${selfRating} — ${RATING_SCALE[selfRating as keyof typeof RATING_SCALE]?.label ?? ""}`
+                          : "Not rated"}
+                      </p>
+                      {selfNotes && selfNotes.trim() !== "" && (
+                        <p className="text-xs text-muted-foreground whitespace-pre-wrap">
+                          {selfNotes}
+                        </p>
+                      )}
+                    </div>
+
+                    {/* Manager assessment column */}
+                    <div className="p-4 space-y-1.5">
+                      <p className="text-xs font-medium text-muted-foreground">
+                        Manager&apos;s Assessment
+                      </p>
+                      <p className="text-sm">
+                        {mgrRating != null
+                          ? `${mgrRating} — ${RATING_SCALE[mgrRating as keyof typeof RATING_SCALE]?.label ?? ""}`
+                          : "Not rated"}
+                      </p>
+                      {mgrNotes && mgrNotes.trim() !== "" && (
+                        <p className="text-xs text-muted-foreground whitespace-pre-wrap">
+                          {mgrNotes}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Development Plan */}
+          {review.developmentPlan && review.developmentPlan.status !== "not_started" && (
+            <div className="rounded-lg border border-border bg-card p-5 space-y-4">
+              <h3 className="text-sm font-semibold text-foreground">Development Plan</h3>
+
+              {review.developmentPlan.areasOfImprovement?.length > 0 && (
+                <div className="space-y-3">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Areas of Improvement
+                  </p>
+                  {review.developmentPlan.areasOfImprovement.map((area, i) => (
+                    <div key={i} className="rounded-md border border-border bg-muted/20 p-3 space-y-1.5">
+                      <p className="text-sm font-medium">{area.area}</p>
+                      {area.actions?.length > 0 && (
+                        <ul className="space-y-0.5 pl-4 list-disc">
+                          {area.actions.map((action, j) => (
+                            <li key={j} className="text-xs text-muted-foreground">
+                              {action}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                      <div className="flex gap-4 text-xs text-muted-foreground pt-1">
+                        {area.timeline && (
+                          <span>
+                            <span className="font-medium">Timeline:</span> {area.timeline}
+                          </span>
+                        )}
+                        {area.owner && (
+                          <span>
+                            <span className="font-medium">Owner:</span> {area.owner}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {review.developmentPlan.managerCommitments?.length > 0 && (
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Manager Commitments
+                  </p>
+                  <ul className="space-y-0.5 pl-4 list-disc">
+                    {review.developmentPlan.managerCommitments.map((c, i) => (
+                      <li key={i} className="text-xs text-muted-foreground">
+                        {c}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {review.developmentPlan.nextReviewDate && (
+                <div className="space-y-1">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Next Review Date
+                  </p>
+                  <p className="text-sm">
+                    {new Date(review.developmentPlan.nextReviewDate).toLocaleDateString()}
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Sign-off row */}
+          <div className="flex flex-col items-end gap-2 pt-4 border-t border-border">
+            {!acknowledged && (
+              <>
+                <p className="text-xs text-muted-foreground">
+                  By signing off you confirm you have reviewed and understand this assessment.
+                </p>
+                {ackError && <p className="text-xs text-red-500">{ackError}</p>}
+                <Button
+                  onClick={handleAcknowledge}
+                  disabled={isAcknowledging}
+                  style={{ backgroundColor: accentColor }}
+                  className="text-white"
+                >
+                  {isAcknowledging ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Signing off…
+                    </>
+                  ) : (
+                    "Sign Off →"
+                  )}
+                </Button>
+              </>
+            )}
+            {acknowledged && (
+              <div
+                className="flex items-center gap-1.5 text-sm"
+                style={{ color: accentColor }}
+              >
+                <CheckCircle2 className="h-4 w-4" />
+                Acknowledged
+              </div>
+            )}
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/platform/src/components/grow/performance-reviews/category-section-card.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/category-section-card.tsx
@@ -1,10 +1,24 @@
 "use client";
 
+import { useState } from "react";
 import { Textarea } from "@ascenta/ui/textarea";
 import { Label } from "@ascenta/ui/label";
 import { REVIEW_CATEGORIES, RATING_SCALE } from "@ascenta/db/performance-review-categories";
 import type { ReviewCategoryKey } from "@ascenta/db/performance-review-categories";
 import { LikertScale } from "@/components/grow/check-in/likert-scale";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+export interface EvidenceItem {
+  id: string;
+  kind: "goal" | "checkin" | "note";
+  label: string;
+}
+
+export interface EvidenceRef {
+  type: "goal" | "checkin" | "note" | "other";
+  refId: string;
+  label: string;
+}
 
 interface CategorySectionCardProps {
   categoryKey: ReviewCategoryKey;
@@ -19,6 +33,9 @@ interface CategorySectionCardProps {
   onBlur?: () => void;
   employeeRating?: number | null;
   employeeNotes?: string;
+  evidenceItems?: EvidenceItem[];
+  selectedEvidence?: EvidenceRef[];
+  onEvidenceChange?: (refs: EvidenceRef[]) => void;
 }
 
 export function CategorySectionCard({
@@ -34,8 +51,45 @@ export function CategorySectionCard({
   onBlur,
   employeeRating = undefined,
   employeeNotes = undefined,
+  evidenceItems = undefined,
+  selectedEvidence = undefined,
+  onEvidenceChange = undefined,
 }: CategorySectionCardProps) {
   const category = REVIEW_CATEGORIES[categoryKey];
+  const [isEvidenceOpen, setIsEvidenceOpen] = useState(false);
+
+  const handleEvidenceToggle = (item: EvidenceItem) => {
+    if (!onEvidenceChange) return;
+
+    const newRefs = selectedEvidence ? [...selectedEvidence] : [];
+    const evidenceRef: EvidenceRef = {
+      type: item.kind === "checkin" ? "checkin" : item.kind,
+      refId: item.id,
+      label: item.label,
+    };
+
+    const existingIndex = newRefs.findIndex((ref) => ref.refId === item.id);
+    if (existingIndex >= 0) {
+      newRefs.splice(existingIndex, 1);
+    } else {
+      newRefs.push(evidenceRef);
+    }
+
+    onEvidenceChange(newRefs);
+  };
+
+  const isItemSelected = (itemId: string): boolean => {
+    return selectedEvidence?.some((ref) => ref.refId === itemId) ?? false;
+  };
+
+  const groupedEvidence =
+    evidenceItems && evidenceItems.length > 0
+      ? {
+          goals: evidenceItems.filter((item) => item.kind === "goal"),
+          checkIns: evidenceItems.filter((item) => item.kind === "checkin"),
+          notes: evidenceItems.filter((item) => item.kind === "note"),
+        }
+      : null;
 
   return (
     <div className="rounded-lg border border-border bg-card p-5 space-y-4">
@@ -118,6 +172,143 @@ export function CategorySectionCard({
           className="min-h-[80px] resize-none"
         />
       </div>
+
+      {/* Supporting Evidence Section */}
+      {evidenceItems && (
+        <div className="space-y-2">
+          <button
+            type="button"
+            onClick={() => setIsEvidenceOpen(!isEvidenceOpen)}
+            className="flex w-full items-center justify-between rounded-md px-3 py-2 hover:bg-muted/50 transition-colors"
+          >
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">Supporting Evidence</span>
+              {selectedEvidence && selectedEvidence.length > 0 && (
+                <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                  {selectedEvidence.length} tagged
+                </span>
+              )}
+            </div>
+            {isEvidenceOpen ? (
+              <ChevronUp className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            )}
+          </button>
+
+          {isEvidenceOpen && (
+            <div className="space-y-3 rounded-md border border-border bg-muted/20 p-3">
+              {groupedEvidence ? (
+                <>
+                  {/* Goals */}
+                  {groupedEvidence.goals.length > 0 && (
+                    <div className="space-y-1.5">
+                      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                        Goals
+                      </p>
+                      <div className="space-y-1 pl-2">
+                        {groupedEvidence.goals.map((item) => (
+                          <label
+                            key={item.id}
+                            className="flex items-start gap-2 cursor-pointer py-1"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={isItemSelected(item.id)}
+                              onChange={() => handleEvidenceToggle(item)}
+                              disabled={disabled}
+                              className="mt-1 w-4 h-4"
+                            />
+                            <span className="text-sm text-foreground break-words">
+                              {item.label}
+                            </span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Check-ins */}
+                  {groupedEvidence.checkIns.length > 0 && (
+                    <div className="space-y-1.5">
+                      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                        Check-ins
+                      </p>
+                      <div className="space-y-1 pl-2">
+                        {groupedEvidence.checkIns.map((item) => (
+                          <label
+                            key={item.id}
+                            className="flex items-start gap-2 cursor-pointer py-1"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={isItemSelected(item.id)}
+                              onChange={() => handleEvidenceToggle(item)}
+                              disabled={disabled}
+                              className="mt-1 w-4 h-4"
+                            />
+                            <span className="text-sm text-foreground break-words">
+                              {item.label}
+                            </span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Notes */}
+                  {groupedEvidence.notes.length > 0 && (
+                    <div className="space-y-1.5">
+                      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                        Notes
+                      </p>
+                      <div className="space-y-1 pl-2">
+                        {groupedEvidence.notes.map((item) => (
+                          <label
+                            key={item.id}
+                            className="flex items-start gap-2 cursor-pointer py-1"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={isItemSelected(item.id)}
+                              onChange={() => handleEvidenceToggle(item)}
+                              disabled={disabled}
+                              className="mt-1 w-4 h-4"
+                            />
+                            <span className="text-sm text-foreground break-words">
+                              {item.label}
+                            </span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <p className="text-xs text-muted-foreground py-2">
+                  No linked items found for this review period.
+                </p>
+              )}
+
+              {/* Read-only evidence display when disabled */}
+              {disabled && selectedEvidence && selectedEvidence.length > 0 && (
+                <div className="space-y-1 pt-2 border-t border-border">
+                  <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                    Tagged Evidence
+                  </p>
+                  <ul className="space-y-1 pl-2">
+                    {selectedEvidence.map((ref) => (
+                      <li key={ref.refId} className="text-sm text-foreground">
+                        • {ref.label}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/platform/src/components/grow/performance-reviews/development-plan-form.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/development-plan-form.tsx
@@ -1,0 +1,522 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+import { Button } from "@ascenta/ui/button";
+import type { DevelopmentPlanStatus } from "@ascenta/db/performance-review-categories";
+import { ChevronLeft, CheckCircle2, Loader2, Plus, Trash2 } from "lucide-react";
+import { cn } from "@ascenta/ui";
+
+interface AreaItem {
+  area: string;
+  actions: string; // textarea: one per line
+  timeline: string;
+  owner: string;
+}
+
+interface DevelopmentPlanValue {
+  areasOfImprovement: AreaItem[];
+  managerCommitments: string; // textarea: one per line
+  nextReviewDate: string; // YYYY-MM-DD for input[type=date]
+}
+
+interface DevelopmentPlanFormProps {
+  reviewId: string;
+  employeeName: string;
+  reviewPeriod: string;
+  accentColor: string;
+  onBack: () => void;
+  onFinalized: () => void;
+}
+
+function buildInitialPlan(): DevelopmentPlanValue {
+  return {
+    areasOfImprovement: [],
+    managerCommitments: "",
+    nextReviewDate: "",
+  };
+}
+
+function serializePlan(plan: DevelopmentPlanValue) {
+  return {
+    areasOfImprovement: plan.areasOfImprovement.map((a) => ({
+      area: a.area,
+      actions: a.actions
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean),
+      timeline: a.timeline,
+      owner: a.owner,
+    })),
+    managerCommitments: plan.managerCommitments
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean),
+    nextReviewDate: plan.nextReviewDate ? new Date(plan.nextReviewDate).toISOString() : null,
+  };
+}
+
+function deserializePlan(raw: {
+  areasOfImprovement?: Array<{
+    area?: string;
+    actions?: string[];
+    timeline?: string;
+    owner?: string;
+  }>;
+  managerCommitments?: string[];
+  nextReviewDate?: string | null;
+}): DevelopmentPlanValue {
+  return {
+    areasOfImprovement: (raw.areasOfImprovement ?? []).map((a) => ({
+      area: a.area ?? "",
+      actions: (a.actions ?? []).join("\n"),
+      timeline: a.timeline ?? "",
+      owner: a.owner ?? "",
+    })),
+    managerCommitments: (raw.managerCommitments ?? []).join("\n"),
+    nextReviewDate: raw.nextReviewDate
+      ? new Date(raw.nextReviewDate).toISOString().slice(0, 10)
+      : "",
+  };
+}
+
+export function DevelopmentPlanForm({
+  reviewId,
+  employeeName,
+  reviewPeriod,
+  accentColor,
+  onBack,
+  onFinalized,
+}: DevelopmentPlanFormProps) {
+  const [plan, setPlan] = useState<DevelopmentPlanValue>(buildInitialPlan);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isFinalizing, setIsFinalizing] = useState(false);
+  const [finalized, setFinalized] = useState(false);
+  const [isLoadingInitial, setIsLoadingInitial] = useState(true);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [finalizeError, setFinalizeError] = useState<string | null>(null);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const planRef = useRef<DevelopmentPlanValue>(plan);
+  // True if status is already "draft" or "finalized" — so first save doesn't re-send status
+  const hasFirstSavedRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadPlan() {
+      try {
+        const res = await fetch(`/api/grow/reviews/${reviewId}`);
+        if (!res.ok) {
+          if (!cancelled)
+            setSaveError("Could not load saved progress. Your changes will still be saved.");
+          return;
+        }
+        if (cancelled) return;
+
+        const data = await res.json();
+        const devPlan = data?.review?.developmentPlan;
+        const devStatus: DevelopmentPlanStatus = devPlan?.status ?? "not_started";
+
+        if (!cancelled) {
+          if (devStatus !== "not_started") {
+            hasFirstSavedRef.current = true;
+          }
+          if (devStatus === "finalized") {
+            setFinalized(true);
+          }
+          if (devPlan) {
+            const loaded = deserializePlan(devPlan);
+            setPlan(loaded);
+            planRef.current = loaded;
+          }
+        }
+      } finally {
+        if (!cancelled) setIsLoadingInitial(false);
+      }
+    }
+
+    loadPlan();
+    return () => {
+      cancelled = true;
+    };
+  }, [reviewId]);
+
+  const savePlan = useCallback(
+    async (current: DevelopmentPlanValue) => {
+      setIsSaving(true);
+      try {
+        const body: Record<string, unknown> = { ...serializePlan(current) };
+        if (!hasFirstSavedRef.current) {
+          hasFirstSavedRef.current = true;
+          body.status = "draft";
+        }
+
+        const res = await fetch(`/api/grow/reviews/${reviewId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ developmentPlan: body }),
+        });
+
+        if (!res.ok) {
+          const errorData = (await res.json().catch(() => ({}))) as { error?: string };
+          setSaveError(errorData?.error ?? "Failed to save — please try again.");
+        } else {
+          setSaveError(null);
+        }
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [reviewId],
+  );
+
+  const scheduleAutoSave = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      savePlan(planRef.current);
+    }, 500);
+  }, [savePlan]);
+
+  // --- Area helpers ---
+
+  const handleAddArea = useCallback(() => {
+    setPlan((prev) => {
+      const next = {
+        ...prev,
+        areasOfImprovement: [
+          ...prev.areasOfImprovement,
+          { area: "", actions: "", timeline: "", owner: "" },
+        ],
+      };
+      planRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const handleRemoveArea = useCallback(
+    (index: number) => {
+      setPlan((prev) => {
+        const next = {
+          ...prev,
+          areasOfImprovement: prev.areasOfImprovement.filter((_, i) => i !== index),
+        };
+        planRef.current = next;
+        savePlan(next);
+        return next;
+      });
+    },
+    [savePlan],
+  );
+
+  const handleAreaChange = useCallback(
+    (index: number, field: keyof AreaItem, value: string) => {
+      setPlan((prev) => {
+        const next = {
+          ...prev,
+          areasOfImprovement: prev.areasOfImprovement.map((a, i) =>
+            i === index ? { ...a, [field]: value } : a,
+          ),
+        };
+        planRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
+
+  const handleCommitmentsChange = useCallback((value: string) => {
+    setPlan((prev) => {
+      const next = { ...prev, managerCommitments: value };
+      planRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const handleDateChange = useCallback((value: string) => {
+    setPlan((prev) => {
+      const next = { ...prev, nextReviewDate: value };
+      planRef.current = next;
+      return next;
+    });
+  }, []);
+
+  // --- Finalize ---
+
+  const handleFinalize = useCallback(async () => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+
+    setIsFinalizing(true);
+    setFinalizeError(null);
+    try {
+      const res = await fetch(`/api/grow/reviews/${reviewId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          developmentPlan: {
+            status: "finalized",
+            ...serializePlan(planRef.current),
+          },
+        }),
+      });
+
+      if (!res.ok) {
+        const errorData = (await res.json().catch(() => ({}))) as { error?: string };
+        setFinalizeError(errorData?.error ?? "Failed to finalize — please try again.");
+        return;
+      }
+
+      setFinalized(true);
+      onFinalized();
+    } finally {
+      setIsFinalizing(false);
+    }
+  }, [reviewId, onFinalized]);
+
+  const noAreasWarning = plan.areasOfImprovement.length === 0 && !finalized;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <button
+            onClick={onBack}
+            className="mt-0.5 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Back
+          </button>
+          <div>
+            <h2 className="text-base font-semibold text-foreground">Development Plan</h2>
+            <p className="text-sm text-muted-foreground">
+              {employeeName} · {reviewPeriod}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1.5 text-sm shrink-0">
+          {finalized ? (
+            <>
+              <CheckCircle2 className="h-4 w-4" style={{ color: accentColor }} />
+              <span style={{ color: accentColor }} className="font-medium">
+                Finalized
+              </span>
+            </>
+          ) : saveError ? (
+            <span className="text-red-500">{saveError}</span>
+          ) : isSaving ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              <span className="text-muted-foreground">Saving…</span>
+            </>
+          ) : (
+            <span className="text-muted-foreground">Auto-saving</span>
+          )}
+        </div>
+      </div>
+
+      {isLoadingInitial ? (
+        <div className="flex justify-center py-10">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <>
+          {/* Areas of Improvement */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-foreground">Areas of Improvement</h3>
+              {!finalized && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-xs gap-1"
+                  onClick={handleAddArea}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Add area
+                </Button>
+              )}
+            </div>
+
+            {plan.areasOfImprovement.length === 0 && (
+              <p className="text-sm text-muted-foreground italic">
+                No areas added yet.{" "}
+                {!finalized && "Click \u201cAdd area\u201d to add the first item."}
+              </p>
+            )}
+
+            {plan.areasOfImprovement.map((item, index) => (
+              <div
+                key={index}
+                className="rounded-lg border bg-card p-4 space-y-3"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                    Area {index + 1}
+                  </p>
+                  {!finalized && (
+                    <button
+                      onClick={() => handleRemoveArea(index)}
+                      className="text-muted-foreground hover:text-red-500 transition-colors"
+                      aria-label="Remove area"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-xs font-medium text-muted-foreground">Area</label>
+                  <input
+                    type="text"
+                    value={item.area}
+                    disabled={finalized}
+                    onChange={(e) => handleAreaChange(index, "area", e.target.value)}
+                    onBlur={scheduleAutoSave}
+                    placeholder="e.g. Communication with cross-functional teams"
+                    className={cn(
+                      "w-full rounded-md border bg-background px-3 py-1.5 text-sm",
+                      "placeholder:text-muted-foreground/50",
+                      "focus:outline-none focus:ring-2 focus:ring-ring",
+                      "disabled:cursor-not-allowed disabled:opacity-60",
+                    )}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-xs font-medium text-muted-foreground">
+                    Actions <span className="text-muted-foreground/60">(one per line)</span>
+                  </label>
+                  <textarea
+                    value={item.actions}
+                    disabled={finalized}
+                    onChange={(e) => handleAreaChange(index, "actions", e.target.value)}
+                    onBlur={scheduleAutoSave}
+                    placeholder={"e.g. Attend weekly sync\nPresent updates in all-hands"}
+                    rows={3}
+                    className={cn(
+                      "w-full rounded-md border bg-background px-3 py-1.5 text-sm resize-none",
+                      "placeholder:text-muted-foreground/50",
+                      "focus:outline-none focus:ring-2 focus:ring-ring",
+                      "disabled:cursor-not-allowed disabled:opacity-60",
+                    )}
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-2">
+                    <label className="text-xs font-medium text-muted-foreground">Timeline</label>
+                    <input
+                      type="text"
+                      value={item.timeline}
+                      disabled={finalized}
+                      onChange={(e) => handleAreaChange(index, "timeline", e.target.value)}
+                      onBlur={scheduleAutoSave}
+                      placeholder="e.g. Q3 2026"
+                      className={cn(
+                        "w-full rounded-md border bg-background px-3 py-1.5 text-sm",
+                        "placeholder:text-muted-foreground/50",
+                        "focus:outline-none focus:ring-2 focus:ring-ring",
+                        "disabled:cursor-not-allowed disabled:opacity-60",
+                      )}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-xs font-medium text-muted-foreground">Owner</label>
+                    <input
+                      type="text"
+                      value={item.owner}
+                      disabled={finalized}
+                      onChange={(e) => handleAreaChange(index, "owner", e.target.value)}
+                      onBlur={scheduleAutoSave}
+                      placeholder="e.g. Employee + Manager"
+                      className={cn(
+                        "w-full rounded-md border bg-background px-3 py-1.5 text-sm",
+                        "placeholder:text-muted-foreground/50",
+                        "focus:outline-none focus:ring-2 focus:ring-ring",
+                        "disabled:cursor-not-allowed disabled:opacity-60",
+                      )}
+                    />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Manager Commitments */}
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold text-foreground">Manager Commitments</h3>
+            <p className="text-xs text-muted-foreground">One commitment per line.</p>
+            <textarea
+              value={plan.managerCommitments}
+              disabled={finalized}
+              onChange={(e) => handleCommitmentsChange(e.target.value)}
+              onBlur={scheduleAutoSave}
+              placeholder={"e.g. Provide bi-weekly feedback sessions\nShare relevant resources and training opportunities"}
+              rows={4}
+              className={cn(
+                "w-full rounded-md border bg-background px-3 py-2 text-sm resize-none",
+                "placeholder:text-muted-foreground/50",
+                "focus:outline-none focus:ring-2 focus:ring-ring",
+                "disabled:cursor-not-allowed disabled:opacity-60",
+              )}
+            />
+          </div>
+
+          {/* Next Review Date */}
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold text-foreground">Next Review Date</h3>
+            <input
+              type="date"
+              value={plan.nextReviewDate}
+              disabled={finalized}
+              onChange={(e) => handleDateChange(e.target.value)}
+              onBlur={scheduleAutoSave}
+              className={cn(
+                "rounded-md border bg-background px-3 py-1.5 text-sm",
+                "focus:outline-none focus:ring-2 focus:ring-ring",
+                "disabled:cursor-not-allowed disabled:opacity-60",
+              )}
+            />
+          </div>
+
+          {/* Footer */}
+          <div className="flex flex-col items-end gap-2 pt-2">
+            {noAreasWarning && (
+              <p className="text-xs text-amber-600">
+                No areas of improvement have been added yet.
+              </p>
+            )}
+            {finalizeError && <p className="text-xs text-red-500">{finalizeError}</p>}
+
+            {finalized ? (
+              <div className="flex items-center gap-1.5 text-sm" style={{ color: accentColor }}>
+                <CheckCircle2 className="h-4 w-4" />
+                Dev Plan Finalized
+              </div>
+            ) : (
+              <Button
+                onClick={handleFinalize}
+                disabled={isFinalizing}
+                className="text-white"
+                style={{ backgroundColor: accentColor }}
+              >
+                {isFinalizing ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Finalizing…
+                  </>
+                ) : (
+                  "Finalize Dev Plan →"
+                )}
+              </Button>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/platform/src/components/grow/performance-reviews/manager-assessment-form.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/manager-assessment-form.tsx
@@ -6,12 +6,14 @@ import { REVIEW_CATEGORY_KEYS } from "@ascenta/db/performance-review-categories"
 import type { ReviewCategoryKey, SelfAssessmentStatus, ManagerAssessmentStatus } from "@ascenta/db/performance-review-categories";
 import { ChevronLeft, CheckCircle2, Loader2 } from "lucide-react";
 import { CategorySectionCard } from "./category-section-card";
+import type { EvidenceItem, EvidenceRef } from "./category-section-card";
 
 interface CategorySectionValue {
   categoryKey: ReviewCategoryKey;
   rating: number | null;
   notes: string;
   examples: string;
+  evidence: EvidenceRef[];
 }
 
 interface ManagerAssessmentFormProps {
@@ -31,7 +33,10 @@ function buildInitialSections(initial: CategorySectionValue[]): CategorySectionV
   }
   return REVIEW_CATEGORY_KEYS.map((key) => {
     const existing = byKey.get(key);
-    return existing ?? { categoryKey: key, rating: null, notes: "", examples: "" };
+    if (existing) {
+      return { ...existing, evidence: existing.evidence ?? [] };
+    }
+    return { categoryKey: key, rating: null, notes: "", examples: "", evidence: [] };
   });
 }
 
@@ -47,6 +52,7 @@ export function ManagerAssessmentForm({
   const [sections, setSections] = useState<CategorySectionValue[]>(() =>
     buildInitialSections([]),
   );
+  const [allEvidenceItems, setAllEvidenceItems] = useState<EvidenceItem[]>([]);
   const [employeeSections, setEmployeeSections] = useState<CategorySectionValue[]>([]);
   const [isSaving, setIsSaving] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -68,14 +74,18 @@ export function ManagerAssessmentForm({
 
     async function loadSections() {
       try {
-        const res = await fetch(`/api/grow/reviews/${reviewId}`);
-        if (!res.ok) {
+        const [reviewRes, evidenceRes] = await Promise.all([
+          fetch(`/api/grow/reviews/${reviewId}`),
+          fetch(`/api/grow/reviews/${reviewId}/evidence`),
+        ]);
+
+        if (!reviewRes.ok) {
           if (!cancelled) setSaveError("Could not load saved progress. Your changes will still be saved.");
           return;
         }
         if (cancelled) return;
 
-        const data = await res.json();
+        const data = await reviewRes.json();
 
         // Load employee's self-assessment sections as read-only reference
         const fetchedEmployeeSections: CategorySectionValue[] =
@@ -86,6 +96,28 @@ export function ManagerAssessmentForm({
           data?.review?.managerAssessment?.sections ?? [];
         const fetchedManagerStatus: ManagerAssessmentStatus =
           data?.review?.managerAssessment?.status ?? initialStatus;
+
+        // Load evidence items (non-blocking — fall back to empty on error)
+        if (evidenceRes.ok) {
+          try {
+            const evidenceData = await evidenceRes.json() as {
+              success: boolean;
+              goals: EvidenceItem[];
+              checkIns: EvidenceItem[];
+              notes: EvidenceItem[];
+            };
+            if (evidenceData.success && !cancelled) {
+              const items: EvidenceItem[] = [
+                ...(evidenceData.goals ?? []),
+                ...(evidenceData.checkIns ?? []),
+                ...(evidenceData.notes ?? []),
+              ];
+              setAllEvidenceItems(items);
+            }
+          } catch {
+            // Evidence fetch failed — form still loads fine with empty items
+          }
+        }
 
         if (!cancelled) {
           setEmployeeSections(fetchedEmployeeSections);
@@ -181,6 +213,18 @@ export function ManagerAssessmentForm({
     }, 500);
   }, [saveSections]);
 
+  const handleEvidenceChange = useCallback(
+    (index: number, refs: EvidenceRef[]) => {
+      setSections((prev) => {
+        const updated = prev.map((s, i) => (i === index ? { ...s, evidence: refs } : s));
+        sectionsRef.current = updated;
+        saveSections(updated);
+        return updated;
+      });
+    },
+    [saveSections],
+  );
+
   const handleSubmit = useCallback(async () => {
     setIsSubmitting(true);
     setSubmitError(null);
@@ -274,6 +318,9 @@ export function ManagerAssessmentForm({
                   onBlur={handleBlur}
                   employeeRating={empSection?.rating ?? null}
                   employeeNotes={empSection?.notes ?? ""}
+                  evidenceItems={allEvidenceItems}
+                  selectedEvidence={section.evidence}
+                  onEvidenceChange={(refs) => handleEvidenceChange(index, refs)}
                 />
               );
             })}

--- a/apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx
+++ b/apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx
@@ -7,6 +7,7 @@ import { Button } from "@ascenta/ui/button";
 import type { ComponentType } from "react";
 import type { SelfAssessmentStatus } from "@ascenta/db/performance-review-categories";
 import { SelfAssessmentForm } from "./self-assessment-form";
+import { AcknowledgmentView } from "./acknowledgment-view";
 
 interface ReviewSummary {
   id: string;
@@ -14,6 +15,7 @@ interface ReviewSummary {
   reviewPeriod: string;
   reviewType: string;
   selfAssessmentStatus: SelfAssessmentStatus;
+  status: string;
 }
 
 interface SelfAssessmentPanelProps {
@@ -23,7 +25,7 @@ interface SelfAssessmentPanelProps {
 }
 
 const STATUS_CONFIG: Record<
-  SelfAssessmentStatus,
+  string,
   {
     label: string;
     bg: string;
@@ -49,6 +51,18 @@ const STATUS_CONFIG: Record<
     text: "text-blue-600",
     icon: CheckCircle,
   },
+  finalized: {
+    label: "Ready to Review",
+    bg: "bg-blue-500/15",
+    text: "text-blue-600",
+    icon: CheckCircle,
+  },
+  acknowledged: {
+    label: "Acknowledged",
+    bg: "bg-gray-500/15",
+    text: "text-gray-500",
+    icon: CheckCircle,
+  },
 };
 
 export function SelfAssessmentPanel({
@@ -59,6 +73,7 @@ export function SelfAssessmentPanel({
   const [reviews, setReviews] = useState<ReviewSummary[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [activeReviewId, setActiveReviewId] = useState<string | null>(null);
+  const [activeAckReviewId, setActiveAckReviewId] = useState<string | null>(null);
 
   const fetchReviews = useCallback(async () => {
     setIsLoading(true);
@@ -80,6 +95,23 @@ export function SelfAssessmentPanel({
   }, [employeeObjectId, fetchReviews]);
 
   const activeReview = reviews.find((r) => r.id === activeReviewId) ?? null;
+  const activeAckReview = reviews.find((r) => r.id === activeAckReviewId) ?? null;
+
+  if (activeAckReview) {
+    return (
+      <AcknowledgmentView
+        reviewId={activeAckReview.id}
+        employeeName={activeAckReview.employeeName}
+        reviewPeriod={activeAckReview.reviewPeriod}
+        accentColor={accentColor}
+        onBack={() => setActiveAckReviewId(null)}
+        onAcknowledged={() => {
+          fetchReviews();
+          setActiveAckReviewId(null);
+        }}
+      />
+    );
+  }
 
   if (activeReview) {
     return (
@@ -118,7 +150,12 @@ export function SelfAssessmentPanel({
           </div>
         ) : (
           reviews.map((review) => {
-            const config = STATUS_CONFIG[review.selfAssessmentStatus] ?? STATUS_CONFIG["not_started"];
+            // For badge display: use overall status for finalized/acknowledged, else selfAssessmentStatus
+            const displayStatus =
+              review.status === "finalized" || review.status === "acknowledged"
+                ? review.status
+                : review.selfAssessmentStatus;
+            const config = STATUS_CONFIG[displayStatus] ?? STATUS_CONFIG["not_started"];
             const Icon = config.icon;
             return (
               <div key={review.id} className="flex items-center gap-3 px-4 py-3">
@@ -140,20 +177,33 @@ export function SelfAssessmentPanel({
                   <Icon className="h-3 w-3" />
                   {config.label}
                 </span>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 shrink-0 px-2 text-xs"
-                  style={{ color: accentColor }}
-                  onClick={() => setActiveReviewId(review.id)}
-                >
-                  {review.selfAssessmentStatus === "not_started"
-                    ? "Start"
-                    : review.selfAssessmentStatus === "in_progress"
-                      ? "Continue"
-                      : "View"}
-                  <ChevronRight className="ml-0.5 h-3 w-3" />
-                </Button>
+                {review.status === "finalized" ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 shrink-0 px-2 text-xs"
+                    style={{ color: accentColor }}
+                    onClick={() => setActiveAckReviewId(review.id)}
+                  >
+                    View &amp; Sign Off
+                    <ChevronRight className="ml-0.5 h-3 w-3" />
+                  </Button>
+                ) : review.status === "acknowledged" ? null : (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 shrink-0 px-2 text-xs"
+                    style={{ color: accentColor }}
+                    onClick={() => setActiveReviewId(review.id)}
+                  >
+                    {review.selfAssessmentStatus === "not_started"
+                      ? "Start"
+                      : review.selfAssessmentStatus === "in_progress"
+                        ? "Continue"
+                        : "View"}
+                    <ChevronRight className="ml-0.5 h-3 w-3" />
+                  </Button>
+                )}
               </div>
             );
           })

--- a/apps/platform/src/components/grow/reviews-panel.tsx
+++ b/apps/platform/src/components/grow/reviews-panel.tsx
@@ -18,6 +18,7 @@ import { useChat } from "@/lib/chat/chat-context";
 import { useAuth } from "@/lib/auth/auth-context";
 import { AlertCircle, Download, Users, Clock, CheckCircle, FileX } from "lucide-react";
 import { ManagerAssessmentForm } from "./performance-reviews/manager-assessment-form";
+import { DevelopmentPlanForm } from "./performance-reviews/development-plan-form";
 import type { ManagerAssessmentStatus } from "@ascenta/db/performance-review-categories";
 
 interface ReviewEntry {
@@ -31,6 +32,7 @@ interface ReviewEntry {
   reviewId: string | null;
   selfAssessmentStatus: string;
   managerAssessmentStatus: string;
+  devPlanStatus: string;
 }
 
 interface ReviewAggregates {
@@ -80,10 +82,15 @@ export function ReviewsPanel({ pageKey, accentColor, onSwitchToDoTab }: ReviewsP
   const [period, setPeriod] = useState(getCurrentPeriod());
   const [isLoading, setIsLoading] = useState(true);
   const [activeAssessmentReviewId, setActiveAssessmentReviewId] = useState<string | null>(null);
+  const [activePlanReviewId, setActivePlanReviewId] = useState<string | null>(null);
   const { sendMessage } = useChat();
 
   const activeAssessmentReview = activeAssessmentReviewId
     ? (reviews.find((r) => r.reviewId === activeAssessmentReviewId) ?? null)
+    : null;
+
+  const activePlanReview = activePlanReviewId
+    ? (reviews.find((r) => r.reviewId === activePlanReviewId) ?? null)
     : null;
 
   const fetchReviews = useCallback(async () => {
@@ -138,6 +145,23 @@ export function ReviewsPanel({ pageKey, accentColor, onSwitchToDoTab }: ReviewsP
     window.open(`/api/grow/reviews/${reviewId}/pdf`, "_blank");
   };
 
+  const [finalizeReviewError, setFinalizeReviewError] = useState<string | null>(null);
+
+  const handleFinalizeReview = async (reviewId: string) => {
+    setFinalizeReviewError(null);
+    const res = await fetch(`/api/grow/reviews/${reviewId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "finalized" }),
+    });
+    if (res.ok) {
+      fetchReviews();
+    } else {
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      setFinalizeReviewError(data.error ?? "Failed to finalize review. Please try again.");
+    }
+  };
+
   const dueWithin2Weeks = aggregates.notStarted > 0;
 
   if (activeAssessmentReview) {
@@ -152,6 +176,22 @@ export function ReviewsPanel({ pageKey, accentColor, onSwitchToDoTab }: ReviewsP
         onSubmitted={() => {
           fetchReviews();
           setActiveAssessmentReviewId(null);
+        }}
+      />
+    );
+  }
+
+  if (activePlanReview) {
+    return (
+      <DevelopmentPlanForm
+        reviewId={activePlanReview.reviewId!}
+        employeeName={activePlanReview.employeeName}
+        reviewPeriod={period}
+        accentColor={accentColor}
+        onBack={() => setActivePlanReviewId(null)}
+        onFinalized={() => {
+          fetchReviews();
+          setActivePlanReviewId(null);
         }}
       />
     );
@@ -235,6 +275,13 @@ export function ReviewsPanel({ pageKey, accentColor, onSwitchToDoTab }: ReviewsP
               ))}
             </SelectContent>
           </Select>
+        </div>
+      )}
+
+      {/* Finalize review error */}
+      {finalizeReviewError && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-2.5 text-sm text-red-600">
+          {finalizeReviewError}
         </div>
       )}
 
@@ -341,6 +388,29 @@ export function ReviewsPanel({ pageKey, accentColor, onSwitchToDoTab }: ReviewsP
                         >
                           Continue Assessment →
                         </Button>
+                      )}
+                      {review.status === "draft_complete" && review.reviewId && (
+                        review.devPlanStatus === "finalized" ? (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 text-xs"
+                            style={{ color: accentColor }}
+                            onClick={() => handleFinalizeReview(review.reviewId!)}
+                          >
+                            Finalize Review →
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 text-xs"
+                            style={{ color: accentColor }}
+                            onClick={() => setActivePlanReviewId(review.reviewId!)}
+                          >
+                            {review.devPlanStatus === "draft" ? "Continue Dev Plan →" : "Complete Dev Plan"}
+                          </Button>
+                        )
                       )}
                       {(review.status === "finalized" || review.status === "shared") && (
                         <Button

--- a/docs/superpowers/plans/2026-04-17-perf-reviews-v2-phase-d.md
+++ b/docs/superpowers/plans/2026-04-17-perf-reviews-v2-phase-d.md
@@ -1,0 +1,518 @@
+# Performance Reviews v2 — Phase D Implementation Plan
+
+**Date:** 2026-04-17
+**Branch:** `feat/perf-reviews-v2-phase-d`
+**Spec:** `docs/superpowers/specs/2026-04-17-perf-reviews-v2-phase-d-design.md`
+**Builds on:** Phase C commit f08902e (main branch)
+
+---
+
+## Task Overview
+
+| # | Task | Depends on |
+|---|---|---|
+| 1 | API: finalize + acknowledge gates; add `status` to employee list | — |
+| 2 | API: evidence endpoint | — |
+| 3 | CategorySectionCard: evidence sidebar UI | — |
+| 4 | ManagerAssessmentForm: wire evidence fetch + saves | 2, 3 |
+| 5 | DevelopmentPlanForm: new component | — |
+| 6 | ReviewsPanel: dev plan + finalize actions | 1, 5 |
+| 7 | AcknowledgmentView + SelfAssessmentPanel extension | 1 |
+
+Tasks 1, 2, 3, and 5 are fully independent. Tasks 4, 6, and 7 each depend on earlier tasks. Suggested order: 1 → 2 → 3 → 5 (parallel if using sub-agents) → 4 → 6 → 7.
+
+---
+
+## Task 1 — API: status gates + employee list `status` field
+
+**Files modified:**
+- `apps/platform/src/app/api/grow/reviews/route.ts`
+- `apps/platform/src/app/api/grow/reviews/[id]/route.ts`
+
+### 1a — Employee list: add `status` to response
+
+In `route.ts`, the `employeeObjectId` branch (~line 27) maps reviews. Add `status` to each entry:
+
+```typescript
+status: (r.status as string) ?? "not_started",
+```
+
+The `ReviewSummary` interface in `self-assessment-panel.tsx` also gains `status: string` (updated in Task 7).
+
+### 1b — PATCH: finalize gate
+
+In `[id]/route.ts`, after the `managerAssessmentWorkBeingWritten` guard block (~line 91), add:
+
+```typescript
+if (data.status === "finalized") {
+  const devPlanStatus = review.developmentPlan?.status ?? "not_started";
+  if (devPlanStatus !== "finalized") {
+    return NextResponse.json(
+      { success: false, error: "Development plan must be finalized before the review can be finalized." },
+      { status: 422 }
+    );
+  }
+}
+```
+
+### 1c — PATCH: acknowledge gate
+
+Immediately after the finalize gate:
+
+```typescript
+if (data.status === "acknowledged") {
+  if (review.status !== "finalized") {
+    return NextResponse.json(
+      { success: false, error: "Review must be finalized before it can be acknowledged." },
+      { status: 422 }
+    );
+  }
+}
+```
+
+**Pitfall:** Both guards must execute **before** `updateOps` is built and `findByIdAndUpdate` is called. Place them right after the existing manager-assessment gate block, before the `updateOps` object is assembled.
+
+**Commit:** `feat: add finalize and acknowledge status gates to PATCH /api/grow/reviews/[id]`
+
+---
+
+## Task 2 — API: evidence endpoint
+
+**File created:** `apps/platform/src/app/api/grow/reviews/[id]/evidence/route.ts`
+
+Create a `GET` handler only. Steps:
+
+1. `await connectDB()`
+2. Look up the review: `PerformanceReview.findById(id).lean()` — need `employee`, `reviewPeriod.start`, `reviewPeriod.end`
+3. Return 404 if not found
+4. Run three queries in parallel via `Promise.all`:
+   - `Goal.find({ owner: review.employee, "timePeriod.end": { $gte: reviewPeriod.start }, "timePeriod.start": { $lte: reviewPeriod.end } }).select("_id objectiveStatement goalType status").lean()`
+   - `CheckIn.find({ employee: review.employee, scheduledDate: { $gte: reviewPeriod.start, $lte: reviewPeriod.end } }).select("_id participate.completedAt participate.managerCommitment participate.employeeCommitment").lean()`
+   - `PerformanceNote.find({ employee: review.employee, createdAt: { $gte: reviewPeriod.start, $lte: reviewPeriod.end } }).select("_id type observation createdAt").lean()`
+5. Map each to a minimal shape:
+   - Goal: `{ id: String(g._id), kind: "goal", label: g.objectiveStatement, category: g.goalType, status: g.status }`
+   - CheckIn: `{ id: String(c._id), kind: "checkin", label: formatCheckInLabel(c) }` where `formatCheckInLabel` returns a short string like `"Check-in · Mar 15, 2026"` using `c.participate?.completedAt`
+   - Note: `{ id: String(n._id), kind: "note", label: \`${n.type}: ${n.observation.slice(0, 60)}…\` }`
+6. Return `{ success: true, goals, checkIns, notes }`
+
+**Client-safe import pitfall:** This is a server route file — it can import from `@ascenta/db/goal-schema`, `@ascenta/db/checkin-schema`, `@ascenta/db/performance-note-schema` safely. Do NOT import these from any client component.
+
+**Pitfall:** `CheckIn` schema uses `scheduledDate` as the date field. Confirm import name: `import { CheckIn } from "@ascenta/db/checkin-schema"` — the model export is `CheckIn`.
+
+**Commit:** `feat: add GET /api/grow/reviews/[id]/evidence endpoint`
+
+---
+
+## Task 3 — CategorySectionCard: evidence sidebar
+
+**File modified:** `apps/platform/src/components/grow/performance-reviews/category-section-card.tsx`
+
+### New types (define at top of file, client-safe — no mongoose)
+
+```typescript
+export interface EvidenceItem {
+  id: string;
+  kind: "goal" | "checkin" | "note";
+  label: string;
+}
+
+export interface EvidenceRef {
+  type: "goal" | "checkin" | "note" | "other";
+  refId: string;
+  label: string;
+}
+```
+
+### New props on `CategorySectionCardProps`
+
+```typescript
+evidenceItems?: EvidenceItem[];
+selectedEvidence?: EvidenceRef[];
+onEvidenceChange?: (refs: EvidenceRef[]) => void;
+```
+
+### Render changes
+
+Add a collapsible evidence section at the very bottom of the card, after the "Specific Examples" block, when `evidenceItems` is provided:
+
+- Use a React `useState<boolean>` for `isOpen` (default `false`)
+- Collapsed state: a small button showing "Supporting Evidence (N tagged)" or "Tag evidence →" using `selectedEvidence?.length`
+- Expanded state: group items by `kind` with headings "Goals", "Check-ins", "Notes". Each item is a checkbox row.
+- Checkbox `onChange`: compute new `EvidenceRef[]` by adding or removing the item. Call `onEvidenceChange(newRefs)`. Match by `id`/`refId` to avoid duplicates.
+- When `disabled` prop is true: if `selectedEvidence` has entries, render them as a flat read-only list. If empty, render nothing. Never render checkboxes when disabled.
+- When `evidenceItems` is empty array: render "No linked items found for this review period." inside the expanded panel.
+
+**Pitfall:** `evidenceItems` is passed from the parent, which has all items. The card does not fetch anything — it only renders what it's given. This keeps the card simple and the fetch centralized in the form.
+
+**Commit:** `feat: add evidence sidebar to CategorySectionCard`
+
+---
+
+## Task 4 — ManagerAssessmentForm: wire evidence
+
+**File modified:** `apps/platform/src/components/grow/performance-reviews/manager-assessment-form.tsx`
+
+### State additions
+
+```typescript
+const [evidenceData, setEvidenceData] = useState<{
+  goals: EvidenceItem[];
+  checkIns: EvidenceItem[];
+  notes: EvidenceItem[];
+} | null>(null);
+const [sections, setSections] = useState<CategorySectionValue[]>(() => buildInitialSections([]));
+// extend CategorySectionValue to include evidence:
+// evidence: EvidenceRef[]  (already in the schema, just not in the TS interface yet)
+```
+
+Extend `CategorySectionValue` to include `evidence: EvidenceRef[]`:
+```typescript
+interface CategorySectionValue {
+  categoryKey: ReviewCategoryKey;
+  rating: number | null;
+  notes: string;
+  examples: string;
+  evidence: EvidenceRef[];
+}
+```
+Update `buildInitialSections` to default `evidence: []` and pick up evidence from fetched sections.
+
+### Load evidence in parallel
+
+In the existing `loadSections` effect, add a second fetch in `Promise.all`:
+
+```typescript
+const [reviewRes, evidenceRes] = await Promise.all([
+  fetch(`/api/grow/reviews/${reviewId}`),
+  fetch(`/api/grow/reviews/${reviewId}/evidence`),
+]);
+```
+
+On success, map the evidence response into flat `EvidenceItem[]`:
+```typescript
+const allItems: EvidenceItem[] = [
+  ...goals.map((g) => ({ id: g.id, kind: "goal" as const, label: g.label })),
+  ...checkIns.map((c) => ({ id: c.id, kind: "checkin" as const, label: c.label })),
+  ...notes.map((n) => ({ id: n.id, kind: "note" as const, label: n.label })),
+];
+setEvidenceData({ goals: allItems.filter(i => i.kind === "goal"), ... });
+```
+
+Or simpler: store a single flat `allEvidenceItems: EvidenceItem[]` array — the card groups by `kind` itself.
+
+### Pass to CategorySectionCard
+
+In the render loop:
+```tsx
+<CategorySectionCard
+  ...existing props...
+  evidenceItems={allEvidenceItems}
+  selectedEvidence={section.evidence}
+  onEvidenceChange={(refs) => handleEvidenceChange(index, refs)}
+/>
+```
+
+`handleEvidenceChange`:
+```typescript
+const handleEvidenceChange = useCallback((index: number, refs: EvidenceRef[]) => {
+  setSections((prev) => {
+    const updated = prev.map((s, i) => i === index ? { ...s, evidence: refs } : s);
+    sectionsRef.current = updated;
+    saveSections(updated);  // immediate save (no debounce — checkbox interaction)
+    return updated;
+  });
+}, [saveSections]);
+```
+
+**Pitfall:** `saveSections` already serializes the full sections array including `evidence`. No changes to the PATCH body structure are needed — evidence is just another field in each section object that gets written along with rating/notes/examples.
+
+**Pitfall:** `evidenceRes` may 404 or 500 in edge cases (no goals/check-ins in the period). Handle gracefully: catch errors and default `allEvidenceItems` to `[]`. Do not block the form from loading.
+
+**Commit:** `feat: wire evidence fetch and category tagging into ManagerAssessmentForm`
+
+---
+
+## Task 5 — DevelopmentPlanForm: new component
+
+**File created:** `apps/platform/src/components/grow/performance-reviews/development-plan-form.tsx`
+
+Mirror the structure of `SelfAssessmentForm` / `ManagerAssessmentForm`. Key patterns:
+
+- `"use client"` directive
+- Imports from `@ascenta/ui/*` and `@ascenta/db/performance-review-categories` (client-safe) only
+- `planRef` instead of `sectionsRef` — holds `{ areasOfImprovement, managerCommitments, nextReviewDate }`
+- `hasFirstSavedRef` — initialized to `initialStatus !== "not_started"`
+- Auto-save on blur: 500ms debounced `PATCH /api/grow/reviews/${reviewId}` with `{ developmentPlan: { status: "draft", ...planRef.current } }`
+- On first save when status is `not_started`: include `status: "draft"` in the payload, set `hasFirstSavedRef.current = true`
+
+Data fetch on mount:
+```typescript
+const res = await fetch(`/api/grow/reviews/${reviewId}`);
+// load review.developmentPlan — populate form fields
+// if developmentPlan.status === "finalized", set finalized=true (read-only)
+```
+
+Form fields:
+- **Areas of Improvement**: dynamic array of `{ area, actions, timeline, owner }`. Use `useState<AreaItem[]>`. Each area row is a bordered sub-card with: a text input for `area`, a textarea for `actions` (one per line — split on `\n` for save), a text input for `timeline`, a text input for `owner`, and a "Remove" button.
+- **Manager Commitments**: single textarea, one commitment per line. On save, split on `\n` to produce `string[]`.
+- **Next Review Date**: `<input type="date" />`. On save, serialize to ISO string.
+
+"Finalize Dev Plan" button:
+1. Clear debounce timer
+2. PATCH `{ developmentPlan: { status: "finalized", areasOfImprovement, managerCommitments, nextReviewDate } }`
+3. On success: `setFinalized(true)`, call `onFinalized()`
+
+State variables: `isSaving`, `isFinalizing`, `saveError`, `finalizeError`, `finalized`, `isLoadingInitial`.
+
+Header row (same as other forms): back button, title "Development Plan", auto-save indicator.
+
+**Pitfall:** `managerCommitments` comes back from DB as `string[]` but is edited in a single textarea. On load, join with `"\n"`. On save, split by `"\n"` and filter empty strings.
+
+**Commit:** `feat: add DevelopmentPlanForm component`
+
+---
+
+## Task 6 — ReviewsPanel: dev plan and finalize actions
+
+**File modified:** `apps/platform/src/components/grow/reviews-panel.tsx`
+
+### State additions
+
+```typescript
+const [activePlanReviewId, setActivePlanReviewId] = useState<string | null>(null);
+```
+
+### Derive active review
+
+```typescript
+const activePlanReview = activePlanReviewId
+  ? (reviews.find((r) => r.reviewId === activePlanReviewId) ?? null)
+  : null;
+```
+
+### Conditional render
+
+Add a second early-return block (after the existing `activeAssessmentReview` check):
+
+```tsx
+if (activePlanReview) {
+  return (
+    <DevelopmentPlanForm
+      reviewId={activePlanReview.reviewId!}
+      employeeName={activePlanReview.employeeName}
+      reviewPeriod={period}
+      accentColor={accentColor}
+      onBack={() => setActivePlanReviewId(null)}
+      onFinalized={() => {
+        fetchReviews();
+        setActivePlanReviewId(null);
+      }}
+    />
+  );
+}
+```
+
+### New action buttons
+
+In the table row actions, add (after the existing "Continue Assessment →" button):
+
+```tsx
+{review.status === "draft_complete" && review.reviewId && (
+  <Button
+    variant="ghost"
+    size="sm"
+    className="h-7 text-xs"
+    style={{ color: accentColor }}
+    onClick={() => setActivePlanReviewId(review.reviewId!)}
+  >
+    {review.devPlanStatus === "draft" ? "Continue Dev Plan →" : "Complete Dev Plan"}
+  </Button>
+)}
+{review.status === "draft_complete" && review.devPlanStatus === "finalized" && review.reviewId && (
+  <Button
+    variant="ghost"
+    size="sm"
+    className="h-7 text-xs"
+    style={{ color: accentColor }}
+    onClick={() => handleFinalizeReview(review.reviewId!)}
+  >
+    Finalize Review →
+  </Button>
+)}
+```
+
+### `ReviewEntry` interface extension
+
+Add `devPlanStatus: string` to the `ReviewEntry` interface.
+
+Add to the GET response mapping in `route.ts`:
+```typescript
+devPlanStatus: review ? (review.developmentPlan?.status as string | undefined) ?? "not_started" : "not_started",
+```
+
+### `handleFinalizeReview` handler
+
+```typescript
+const handleFinalizeReview = async (reviewId: string) => {
+  const res = await fetch(`/api/grow/reviews/${reviewId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ status: "finalized" }),
+  });
+  if (res.ok) {
+    fetchReviews();
+  } else {
+    const data = await res.json().catch(() => ({}));
+    console.error("Finalize failed:", data.error);
+  }
+};
+```
+
+**Pitfall:** The "Finalize Review" button and "Continue Dev Plan" button may both be visible if `draft_complete` but `devPlanStatus === "finalized"`. Use `else if` or make the conditions mutually exclusive: show "Finalize Review" only if `devPlanStatus === "finalized"`, otherwise show "Complete/Continue Dev Plan".
+
+**Commit:** `feat: wire development plan and finalize actions into ReviewsPanel`
+
+---
+
+## Task 7 — AcknowledgmentView + SelfAssessmentPanel extension
+
+**Files:**
+- Create: `apps/platform/src/components/grow/performance-reviews/acknowledgment-view.tsx`
+- Modify: `apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx`
+
+### AcknowledgmentView
+
+New component. Fetch `GET /api/grow/reviews/${reviewId}` on mount. Show loading spinner while fetching. Read-only throughout — no auto-save.
+
+Layout:
+1. Back button + header "Performance Review — {reviewPeriod}"
+2. Two-column section heading row: "Your Self-Assessment" (left) and "Manager's Assessment" (right)
+3. For each of the 10 category keys (in `REVIEW_CATEGORY_KEYS` order): a comparison row card showing both assessments side-by-side
+4. Development plan summary block
+5. Sign-off row
+
+Comparison card per category (simple, inline — no need for a separate component file):
+```tsx
+<div className="grid grid-cols-2 gap-4 rounded-lg border bg-card p-4">
+  <div>
+    <p className="text-xs font-semibold text-muted-foreground mb-1">Self-Assessment</p>
+    <p className="text-sm">Rating: {selfRating ? `${selfRating} — ${RATING_SCALE[selfRating].label}` : "Not rated"}</p>
+    {selfNotes && <p className="text-xs text-muted-foreground mt-1">{selfNotes}</p>}
+  </div>
+  <div>
+    <p className="text-xs font-semibold text-muted-foreground mb-1">Manager's Assessment</p>
+    <p className="text-sm">Rating: {mgrRating ? `${mgrRating} — ${RATING_SCALE[mgrRating].label}` : "Not rated"}</p>
+    {mgrNotes && <p className="text-xs text-muted-foreground mt-1">{mgrNotes}</p>}
+  </div>
+</div>
+```
+
+Development plan block (read-only):
+- Each `areasOfImprovement` entry: area + bullet-list of actions + timeline + owner
+- `managerCommitments` as a bullet list
+- `nextReviewDate` formatted as locale date string
+
+Sign-off row:
+```tsx
+<div className="flex flex-col items-end gap-2 pt-4 border-t">
+  {!acknowledged && (
+    <>
+      <p className="text-xs text-muted-foreground">
+        By signing off you confirm you have reviewed and understand this assessment.
+      </p>
+      {ackError && <p className="text-xs text-red-500">{ackError}</p>}
+      <Button onClick={handleAcknowledge} disabled={isAcknowledging} style={{ backgroundColor: accentColor }} className="text-white">
+        {isAcknowledging ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Signing off…</> : "Sign Off →"}
+      </Button>
+    </>
+  )}
+  {acknowledged && (
+    <div className="flex items-center gap-1.5 text-sm" style={{ color: accentColor }}>
+      <CheckCircle2 className="h-4 w-4" /> Acknowledged
+    </div>
+  )}
+</div>
+```
+
+`handleAcknowledge`:
+```typescript
+const handleAcknowledge = async () => {
+  setIsAcknowledging(true);
+  const res = await fetch(`/api/grow/reviews/${reviewId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ status: "acknowledged" }),
+  });
+  if (res.ok) {
+    setAcknowledged(true);
+    onAcknowledged();
+  } else {
+    const data = await res.json().catch(() => ({}));
+    setAckError(data.error ?? "Failed to acknowledge — please try again.");
+  }
+  setIsAcknowledging(false);
+};
+```
+
+### SelfAssessmentPanel changes
+
+1. Add `status: string` to `ReviewSummary` interface
+2. In `STATUS_CONFIG`, add entries for `"finalized"` and `"acknowledged"`:
+   ```typescript
+   finalized: { label: "Ready to Review", bg: "bg-blue-500/15", text: "text-blue-600", icon: CheckCircle },
+   acknowledged: { label: "Acknowledged", bg: "bg-gray-500/15", text: "text-gray-500", icon: CheckCircle },
+   ```
+3. Add `activeAckReviewId` state (same pattern as `activeReviewId`)
+4. Early-return block for acknowledgment view:
+   ```tsx
+   if (activeAckReview) {
+     return <AcknowledgmentView reviewId={...} ... onAcknowledged={() => { fetchReviews(); setActiveAckReviewId(null); }} />;
+   }
+   ```
+5. In each review row, replace single action button with conditional logic:
+   - `status === "finalized"` → "View & Sign Off" button → `setActiveAckReviewId(review.id)`
+   - `status === "acknowledged"` → no button (status badge is sufficient)
+   - Otherwise → existing "Start" / "Continue" / "View" self-assessment button logic
+
+**Pitfall:** `STATUS_CONFIG` is typed `Record<SelfAssessmentStatus, ...>`. Since `finalized` and `acknowledged` are not `SelfAssessmentStatus` values, either widen the type to `Record<string, ...>` or handle the display logic outside of `STATUS_CONFIG` with a fallback.
+
+**Commit:** `feat: add AcknowledgmentView and wire employee sign-off in SelfAssessmentPanel`
+
+---
+
+## Commit Strategy
+
+One commit per task, all on `feat/perf-reviews-v2-phase-d`:
+
+1. `feat: add finalize and acknowledge status gates to PATCH /api/grow/reviews/[id]`
+2. `feat: add GET /api/grow/reviews/[id]/evidence endpoint`
+3. `feat: add evidence sidebar to CategorySectionCard`
+4. `feat: wire evidence fetch and category tagging into ManagerAssessmentForm`
+5. `feat: add DevelopmentPlanForm component`
+6. `feat: wire development plan and finalize actions into ReviewsPanel`
+7. `feat: add AcknowledgmentView and wire employee sign-off in SelfAssessmentPanel`
+
+---
+
+## Dependencies
+
+```
+Task 1 ──────────────────────────────────┐
+Task 2 ──────┐                           │
+Task 3 ──────┤──→ Task 4                 │
+             │                           │
+Task 5 ──────────────────────→ Task 6 ←─┘
+Task 1 ──────────────────────→ Task 7
+```
+
+---
+
+## Definition of Done
+
+- [ ] All 7 tasks committed on `feat/perf-reviews-v2-phase-d`
+- [ ] `pnpm test` passes
+- [ ] `tsc --noEmit` no new errors (pre-existing chat-message.tsx error is acceptable)
+- [ ] No N+1 queries in the evidence endpoint (confirmed: `Promise.all` with 3 parallel queries)
+- [ ] No mongoose imports in client components (evidence types defined inline; all DB access in route files)
+- [ ] Spec compliance review: ✅
+- [ ] PR opened against main

--- a/docs/superpowers/specs/2026-04-17-perf-reviews-v2-phase-d-design.md
+++ b/docs/superpowers/specs/2026-04-17-perf-reviews-v2-phase-d-design.md
@@ -1,0 +1,408 @@
+# Performance Reviews v2 — Phase D Design Spec
+
+**Date:** 2026-04-17
+**Status:** Draft
+**Builds on:** Phase C (f08902e) — manager assessment UI
+**Branch:** `feat/perf-reviews-v2-phase-d`
+
+---
+
+## Context
+
+Phase C delivers the manager's 10-category assessment form with auto-save and a self-assessment reference panel. Phase D closes the review lifecycle with three features: (1) a development plan form the manager must complete before finalizing, (2) evidence surfacing inside the manager assessment so managers can tag supporting goals/check-ins/notes per category, and (3) an employee acknowledgment UI where the employee views a side-by-side comparison and signs off.
+
+---
+
+## Goals
+
+- Give managers a structured development plan form gated on manager assessment submission
+- Prevent finalization until the development plan is complete (`developmentPlan.status === "finalized"`)
+- Surface contextual evidence (goals, check-ins, performance notes) per assessment category so managers can ground ratings in data
+- Let employees view the completed review side-by-side and sign off, advancing status to `acknowledged`
+
+## Non-Goals
+
+- Email/notification to employee when the review is ready — out of scope for Phase D
+- Email/notification to manager when employee acknowledges — out of scope for Phase D
+- PDF export — out of scope for Phase D
+- AI-generated narrative or summary text — out of scope for Phase D
+- Admin override / HR calibration flow — out of scope for Phase D
+
+---
+
+## Data Model
+
+### No new schema changes required
+
+All fields needed for Phase D already exist:
+
+| Field | Location | Notes |
+|---|---|---|
+| `developmentPlan.status` | `DEVELOPMENT_PLAN_STATUSES` enum: `not_started`, `draft`, `finalized` | Already in schema and Zod validation |
+| `developmentPlan.areasOfImprovement[]` | `{ area, actions[], timeline, owner }` | Already in schema |
+| `developmentPlan.managerCommitments[]` | `string[]` | Already in schema |
+| `developmentPlan.nextReviewDate` | `Date` | Already in schema |
+| `managerAssessment.sections[].evidence[]` | `{ type, refId, label }` | Already in schema and Zod |
+| `status: "acknowledged"` | `REVIEW_STATUSES` | Already in enum |
+
+### Status lifecycle
+
+The `deriveReviewStatus` function in `lib/review-transitions.ts` currently handles transitions through `draft_complete`. Phase D adds two additional transitions that are set **explicitly** (not derived), consistent with how `finalized` already works:
+
+```
+not_started
+  → self_in_progress      (employee starts self-assessment)
+  → self_submitted        (employee submits)
+  → manager_in_progress   (manager begins assessment)
+  → draft_complete        (manager submits assessment)
+  → finalized             [NEW gate] set explicitly when dev plan status → "finalized"
+  → acknowledged          [NEW] set explicitly when employee signs off
+```
+
+`draft_complete` is already a terminal status in `deriveReviewStatus` (it stops auto-derive). The PATCH handler respects explicit `status` writes, so the finalize and acknowledge transitions just need to call PATCH with `{ status: "finalized" }` and `{ status: "acknowledged" }` respectively. No changes to `deriveReviewStatus` are needed.
+
+### `REVIEW_STATUS_LABELS` addition
+
+Add label for completeness (already has `"acknowledged": "Acknowledged"` — confirmed present).
+
+---
+
+## API
+
+### Existing endpoints (no new routes needed)
+
+**`GET /api/grow/reviews?employeeObjectId={objectId}`** — already works for the employee acknowledgment view. Returns `{ id, reviewPeriod, reviewType, selfAssessmentStatus }` per review. Needs one addition: return `status` (overall) so the employee panel knows when a review is `finalized` and ready to acknowledge.
+
+**`GET /api/grow/reviews/[id]`** — returns the full review document including both assessment sections, `developmentPlan`, and employee/manager refs. Used by the acknowledgment UI and the dev plan form.
+
+**`PATCH /api/grow/reviews/[id]`** — already handles `developmentPlan`, `managerAssessment.sections` (for evidence writes), and explicit `status` overrides. No structural changes needed.
+
+### Small extension: employee list response
+
+In `GET /api/grow/reviews` (the `employeeObjectId` branch, ~line 28), add `status` to each entry:
+
+```typescript
+status: (r.status as string) ?? "not_started",
+```
+
+This lets `SelfAssessmentPanel` (repurposed as `EmployeeReviewPanel`) know which reviews are `finalized` and show the "View & Sign Off" action.
+
+### Evidence fetch endpoint (new)
+
+**`GET /api/grow/reviews/[id]/evidence`**
+
+Returns goals, check-ins, and performance notes for the review's employee scoped to the review period. One endpoint, no N+1.
+
+Response shape:
+```typescript
+{
+  goals: Array<{ id: string; title: string; category: string; status: string }>;
+  checkIns: Array<{ id: string; completedAt: string | null; managerNotes: string; employeeNotes: string }>;
+  notes: Array<{ id: string; type: string; observation: string; createdAt: string }>;
+}
+```
+
+Query logic (all in one handler, three parallel `find` calls):
+- Goals: `Goal.find({ owner: review.employee, "timePeriod.end": { $gte: review.reviewPeriod.start }, "timePeriod.start": { $lte: review.reviewPeriod.end } })` — select `_id, objectiveStatement, goalType, status`
+- Check-ins: `CheckIn.find({ employee: review.employee, scheduledDate: { $gte: review.reviewPeriod.start, $lte: review.reviewPeriod.end } })` — select `_id, participate.completedAt, participate.managerCommitment, participate.employeeCommitment`
+- Notes: `PerformanceNote.find({ employee: review.employee, createdAt: { $gte: review.reviewPeriod.start, $lte: review.reviewPeriod.end } })` — select `_id, type, observation, createdAt`
+
+Use `Promise.all([...])` — no N+1.
+
+**Auth convention:** No auth layer. Trust the request. The `reviewId` param already scopes the employee; no additional guard needed. Matches existing convention.
+
+### Finalize gate enforcement
+
+When the manager clicks "Finalize Review," the UI sends:
+```
+PATCH /api/grow/reviews/[id]  { status: "finalized" }
+```
+
+The existing PATCH handler accepts explicit `status` writes. However, it does not currently validate that `developmentPlan.status === "finalized"` before allowing a transition to `"finalized"`. Add a guard in the PATCH handler:
+
+```typescript
+if (data.status === "finalized") {
+  const devPlanStatus = review.developmentPlan?.status ?? "not_started";
+  if (devPlanStatus !== "finalized") {
+    return NextResponse.json(
+      { success: false, error: "Development plan must be finalized before the review can be finalized." },
+      { status: 422 }
+    );
+  }
+}
+```
+
+### Acknowledge transition
+
+Employee sends:
+```
+PATCH /api/grow/reviews/[id]  { status: "acknowledged" }
+```
+
+Add a guard: only allow this transition if the review's current status is `"finalized"`:
+
+```typescript
+if (data.status === "acknowledged") {
+  if (review.status !== "finalized") {
+    return NextResponse.json(
+      { success: false, error: "Review must be finalized before it can be acknowledged." },
+      { status: 422 }
+    );
+  }
+}
+```
+
+No employee identity verification beyond trusting the `employeeObjectId` passed by the UI (matches existing self-assessment convention; no auth layer in app).
+
+---
+
+## UI Flows
+
+### Feature 1: Development Plan Form
+
+**Entry point — ReviewsPanel**
+
+When `review.status === "draft_complete"` and `review.reviewId` is set, show a "Complete Dev Plan" button in the action column. Clicking it sets `activePlanReviewId`, which swaps the panel to render `<DevelopmentPlanForm>`.
+
+When `developmentPlan.status === "draft"` (started but not finalized), show a "Continue Dev Plan" button.
+
+When `developmentPlan.status === "finalized"`, show a "Finalize Review" button that sends `PATCH { status: "finalized" }`. On success, refresh the list.
+
+**DevelopmentPlanForm component**
+
+New file: `apps/platform/src/components/grow/performance-reviews/development-plan-form.tsx`
+
+Props:
+```typescript
+interface DevelopmentPlanFormProps {
+  reviewId: string;
+  employeeName: string;
+  reviewPeriod: string;
+  accentColor: string;
+  onBack: () => void;
+  onFinalized: () => void;
+}
+```
+
+Data fetch on mount: `GET /api/grow/reviews/${reviewId}` — loads `developmentPlan` and `managerAssessment.status`.
+
+Layout:
+```
+┌──────────────────────────────────────────────┐
+│ ← Back    Development Plan   [Auto-saving…]  │
+│ Employee Name · Review Period                │
+├──────────────────────────────────────────────┤
+│ Areas of Improvement                         │
+│ [+ Add area]                                 │
+│ Each area row:                               │
+│   Area (text input)                          │
+│   Actions (textarea, line-per-item)          │
+│   Timeline (text input)                      │
+│   Owner (text input)                         │
+│   [Remove]                                   │
+├──────────────────────────────────────────────┤
+│ Manager Commitments                          │
+│ [textarea — one per line, split on save]     │
+├──────────────────────────────────────────────┤
+│ Next Review Date                             │
+│ [date input]                                 │
+├──────────────────────────────────────────────┤
+│                     [Finalize Dev Plan →]    │
+└──────────────────────────────────────────────┘
+```
+
+Auto-save behavior (matching existing forms):
+- Text field `onBlur` → 500ms debounced PATCH `{ developmentPlan: { status: "draft", areasOfImprovement, managerCommitments, nextReviewDate } }`
+- First save advances `developmentPlan.status` to `"draft"` (via `hasFirstSavedRef`)
+- `sectionsRef` equivalent: `planRef` holds current form state for race-free saves
+
+"Finalize Dev Plan" button:
+- PATCH `{ developmentPlan: { status: "finalized", ... all fields } }`
+- On success: call `onFinalized()` → ReviewsPanel refreshes + returns to list and shows the "Finalize Review" button for that row
+
+Read-only when `developmentPlan.status === "finalized"`: all inputs disabled, button replaced with "Dev Plan Finalized ✓"
+
+Completeness warning: warn (don't block) if no areas of improvement are entered.
+
+---
+
+### Feature 2: Evidence Sidebar
+
+**Integration point:** `manager-assessment-form.tsx` and `category-section-card.tsx`
+
+On mount of `ManagerAssessmentForm`, fetch `GET /api/grow/reviews/${reviewId}/evidence` in parallel with the existing review fetch. Store result in `evidenceData` state.
+
+Pass `evidenceData` and a per-category `onEvidenceChange` handler down to each `CategorySectionCard`.
+
+**CategorySectionCard changes**
+
+Add optional props:
+```typescript
+evidenceItems?: EvidenceItem[];       // all available items (goals + check-ins + notes)
+selectedEvidence?: EvidenceRef[];     // current section's evidence[] from DB
+onEvidenceChange?: (refs: EvidenceRef[]) => void;
+```
+
+Where:
+```typescript
+interface EvidenceItem {
+  id: string;
+  kind: "goal" | "checkin" | "note";
+  label: string;         // human-readable: goal title, check-in date, note type + snippet
+}
+interface EvidenceRef {
+  type: "goal" | "checkin" | "note" | "other";
+  refId: string;
+  label: string;
+}
+```
+
+Render a collapsible "Supporting Evidence" section at the bottom of each card (below the examples textarea). Uses a `<details>` or a state-toggled div. When collapsed, show a count badge: "2 items tagged" or "Tag evidence →" if none.
+
+When expanded:
+```
+Supporting Evidence
+───────────────────────────────────────
+Goals
+  ☐ Improve customer response time (active)
+  ☑ Q1 OKR — reduce incidents (achieved)
+Check-ins
+  ☐ 2026-03-15 check-in
+Notes
+  ☑ Coaching: exceeded SLA targets on 3 occasions
+```
+
+Checkbox toggle calls `onEvidenceChange` with the updated `EvidenceRef[]`. Parent saves immediately (no debounce needed — it's a checkbox, not a text field). Save PATCH writes the full sections array as usual; the evidence array is embedded in the section.
+
+Idempotency: Evidence refs are matched by `refId`. Toggle adds or removes by `refId` — no duplicates. The full sections array replaces the DB value on each save (same as notes/rating saves).
+
+Do not show the evidence sidebar when `disabled` (submitted state). When disabled and evidence refs exist, show them read-only as a flat list.
+
+---
+
+### Feature 3: Employee Acknowledgment UI
+
+**Entry point: SelfAssessmentPanel → EmployeeReviewPanel**
+
+`SelfAssessmentPanel` currently shows only `selfAssessmentStatus`. Extend it to also show the overall `status` and handle the `finalized` / `acknowledged` states.
+
+The `GET /api/grow/reviews?employeeObjectId=X` response needs `status` added (per API section above). `ReviewSummary` interface gains:
+```typescript
+status: string;
+```
+
+New action logic per review row:
+- `selfAssessmentStatus !== "submitted"` → existing "Start" / "Continue" / "View" button for the self-assessment
+- `status === "finalized"` → "View & Sign Off" button → opens `AcknowledgmentView`
+- `status === "acknowledged"` → "Acknowledged ✓" indicator (no action)
+
+**AcknowledgmentView component**
+
+New file: `apps/platform/src/components/grow/performance-reviews/acknowledgment-view.tsx`
+
+Props:
+```typescript
+interface AcknowledgmentViewProps {
+  reviewId: string;
+  employeeName: string;
+  reviewPeriod: string;
+  accentColor: string;
+  onBack: () => void;
+  onAcknowledged: () => void;
+}
+```
+
+Data fetch on mount: `GET /api/grow/reviews/${reviewId}` — loads both `selfAssessment.sections` and `managerAssessment.sections`.
+
+Layout — side-by-side comparison:
+```
+┌─────────────────────────────────────────────────────────────┐
+│ ← Back             Performance Review — Q1 2026             │
+│                                                             │
+│  Your Self-Assessment          Manager's Assessment         │
+│  ─────────────────────         ─────────────────────────    │
+│  [For each of 10 categories]                                │
+│  ┌───────────────────────┐    ┌────────────────────────┐   │
+│  │ 1. Job Knowledge      │    │ 1. Job Knowledge        │   │
+│  │ Rating: 3 — Meets     │    │ Rating: 4 — Exceeds     │   │
+│  │ Notes: "..."          │    │ Notes: "..."            │   │
+│  └───────────────────────┘    └────────────────────────┘   │
+│  ...                          ...                           │
+├─────────────────────────────────────────────────────────────┤
+│  Development Plan                                           │
+│  Areas of Improvement: [...]                                │
+│  Manager Commitments: [...]                                 │
+│  Next Review: [date]                                        │
+├─────────────────────────────────────────────────────────────┤
+│  [I have reviewed this assessment and acknowledge receipt]  │
+│                                           [Sign Off →]     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The comparison renders a `ComparisonSectionCard` subcomponent (or inline) per category: category label, then two columns — employee rating + notes (left, read-only) and manager rating + notes (right, read-only). Development plan shown below as a read-only summary block.
+
+"Sign Off" button:
+- PATCH `{ status: "acknowledged" }`
+- On success: call `onAcknowledged()` → panel refreshes + returns to list, row shows "Acknowledged ✓"
+
+No auto-save. Entirely read-only except for the final sign-off action.
+
+---
+
+## File Map
+
+| Action | File |
+|---|---|
+| Modify | `apps/platform/src/app/api/grow/reviews/route.ts` — add `status` to employee view response |
+| Modify | `apps/platform/src/app/api/grow/reviews/[id]/route.ts` — add finalize gate + acknowledge gate to PATCH |
+| Create | `apps/platform/src/app/api/grow/reviews/[id]/evidence/route.ts` — evidence fetch endpoint |
+| Modify | `apps/platform/src/components/grow/performance-reviews/category-section-card.tsx` — add evidence sidebar props + UI |
+| Modify | `apps/platform/src/components/grow/performance-reviews/manager-assessment-form.tsx` — fetch evidence, pass to cards, handle evidence saves |
+| Create | `apps/platform/src/components/grow/performance-reviews/development-plan-form.tsx` |
+| Create | `apps/platform/src/components/grow/performance-reviews/acknowledgment-view.tsx` |
+| Modify | `apps/platform/src/components/grow/performance-reviews/self-assessment-panel.tsx` — add `status` field, `finalized`/`acknowledged` row states, "View & Sign Off" action |
+| Modify | `apps/platform/src/components/grow/reviews-panel.tsx` — add "Complete Dev Plan", "Continue Dev Plan", "Finalize Review" actions + `DevelopmentPlanForm` panel swap |
+
+---
+
+## Acceptance Criteria
+
+### Feature 1 — Development Plan Form
+
+- [ ] `ReviewsPanel` shows "Complete Dev Plan" for `draft_complete` rows; "Continue Dev Plan" for rows where `developmentPlan.status === "draft"`
+- [ ] Clicking either opens `DevelopmentPlanForm` inline (same panel swap pattern)
+- [ ] Form auto-saves on blur; first save advances `developmentPlan.status` to `"draft"`
+- [ ] "Finalize Dev Plan" sets `developmentPlan.status: "finalized"`, returns to list
+- [ ] After dev plan finalized, "Finalize Review" button appears; clicking sends `PATCH { status: "finalized" }`
+- [ ] PATCH handler returns 422 if `status: "finalized"` is requested but `developmentPlan.status !== "finalized"`
+- [ ] Dev plan form renders read-only when `developmentPlan.status === "finalized"`
+
+### Feature 2 — Evidence Sidebar
+
+- [ ] `GET /api/grow/reviews/[id]/evidence` returns goals, check-ins, and performance notes for the employee/period in a single request
+- [ ] Evidence sidebar renders as collapsible within each `CategorySectionCard` when `evidenceItems` prop is provided
+- [ ] Checking an item adds it to `evidence[]` and saves immediately via PATCH
+- [ ] Unchecking removes it; no duplicates by `refId`
+- [ ] Evidence sidebar is hidden / read-only when the manager assessment is in submitted state
+- [ ] If no evidence items exist for the review period, sidebar shows "No linked items found" (not an error)
+
+### Feature 3 — Employee Acknowledgment
+
+- [ ] `GET /api/grow/reviews?employeeObjectId=X` response includes `status` per review entry
+- [ ] `SelfAssessmentPanel` shows "View & Sign Off" for `status === "finalized"` rows
+- [ ] `AcknowledgmentView` loads both self-assessment and manager sections side-by-side in read-only mode
+- [ ] Development plan section shown read-only below the comparison
+- [ ] "Sign Off" sends `PATCH { status: "acknowledged" }` and transitions the review to `acknowledged`
+- [ ] PATCH handler returns 422 if `status: "acknowledged"` is requested but current status is not `"finalized"`
+- [ ] After sign-off, row shows "Acknowledged ✓" state in `SelfAssessmentPanel`
+- [ ] `pnpm test` passes; `tsc --noEmit` no new errors
+
+---
+
+## Out of Scope
+
+- Email notifications of any kind (finalized → employee, acknowledged → manager)
+- AI-generated development plan suggestions
+- PDF export of the completed review
+- Multi-reviewer calibration or override flows
+- Manager editing the review after employee acknowledgment


### PR DESCRIPTION
## Summary

Phase D of the Performance Reviews v2 initiative closes the loop from manager assessment to employee sign-off.

- **Development plan form + finalize gate** — new side-panel form for manager to fill `areasOfImprovement`, `managerCommitments`, `nextReviewDate`. Server blocks `status → finalized` unless the dev plan itself is finalized (422 with descriptive error).
- **Employee acknowledgment UI** — new `AcknowledgmentView` with side-by-side comparison (self-assessment vs manager assessment across all 10 categories) and sign-off button. Server blocks `status → acknowledged` unless review is currently `finalized`.
- **Evidence surfacing** — manager assessment form now fetches goals / check-ins / notes scoped to the review period from a new `GET /api/grow/reviews/[id]/evidence` endpoint and renders a collapsible "Supporting Evidence" panel per category with checkboxes that persist to `evidence[]` on each section.
- **Server auto-stamps** `finalizedAt` and `acknowledgedAt` on status transition.

Out of scope: email notifications (tracked separately, deferred from MVP).

## Commits (9)

| SHA | Task |
|---|---|
| `fbce737` | docs: Phase D spec + plan |
| `7e15ed1` | Task 1 — API status transition gates + employee list `status` |
| `29b865e` | Task 2 — evidence endpoint |
| `0d82e75` | Task 3 — CategorySectionCard evidence sidebar |
| `bae3384` | Task 5 — DevelopmentPlanForm |
| `206bcab` | Task 4 — wire evidence into manager assessment form |
| `bc91ac4` | Task 6 — ReviewsPanel dev plan panel + finalize action |
| `b8ea587` | Task 7 — AcknowledgmentView + self-assessment panel routing |
| `97307ed` | fix: auto-stamp transition timestamps + evidence legacy-field fallback |

## Test plan

- [x] `pnpm test` — 88/88 passing
- [x] `tsc --noEmit` — clean (only pre-existing `chat-message.tsx` TS1501 remains, unrelated)
- [x] Browser smoke: finalize gate (422), acknowledge gate (422)
- [x] Browser smoke: DevelopmentPlanForm renders (Areas / Commitments / Date, auto-save, Finalize)
- [x] Browser smoke: ReviewsPanel shows new actions ("Complete Dev Plan", "Begin Assessment"), period selector, Finalized count updates
- [x] Browser smoke: ManagerAssessmentForm fetches evidence and renders collapsible sidebar with checkboxes
- [x] API: `finalized → acknowledged` transition succeeds and server stamps `acknowledgedAt`
- [ ] End-to-end UI walkthrough of `AcknowledgmentView` sign-off — blocked in smoke testing because all test users with reviews have `role: "manager"`. Code reviewed; PATCH + render logic verified.

## Follow-ups

- Phase F (cycle management, HR UI): #46
- Phase G (analytics/aggregation): #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)