### PR TITLE
feat(perf-reviews): 90-day performance conversation guardrail

### DIFF
--- a/apps/platform/src/app/api/dashboard/attention/route.ts
+++ b/apps/platform/src/app/api/dashboard/attention/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import { connectDB } from "@ascenta/db";
 import { Employee } from "@ascenta/db/employee-schema";
+import { CheckIn } from "@ascenta/db/checkin-schema";
+import { PerformanceNote } from "@ascenta/db/performance-note-schema";
+import { PerformanceReview } from "@ascenta/db/performance-review-schema";
 import { TrackedDocument, WorkflowRun } from "@ascenta/db/workflow-schema";
+import { computeConversationCadence } from "@/lib/perf-reviews/conversation-cadence";
 
 interface AttentionItem {
   id: string;
@@ -11,6 +15,8 @@ interface AttentionItem {
   priority: "high" | "medium" | "low";
   link?: string;
 }
+
+const FINAL_REVIEW_STATUSES = ["finalized", "acknowledged", "shared"];
 
 const PRIORITY_ORDER: Record<string, number> = {
   high: 0,
@@ -116,6 +122,80 @@ export async function GET() {
     }
   } catch (error) {
     console.error("Attention query failed (stalled workflows):", error);
+  }
+
+  // 5. 90-day performance conversation guardrail
+  //    Flags active employees with no completed check-in, performance note,
+  //    or finalized performance review in the last 90+ days.
+  try {
+    const active = await Employee.find({ status: "active" })
+      .select("firstName lastName hireDate status")
+      .lean();
+
+    if (active.length) {
+      const employeeIds = active.map((e) => e._id);
+
+      const [checkInAgg, noteAgg, reviewAgg] = await Promise.all([
+        CheckIn.aggregate([
+          {
+            $match: {
+              employee: { $in: employeeIds },
+              completedAt: { $ne: null },
+            },
+          },
+          { $group: { _id: "$employee", lastAt: { $max: "$completedAt" } } },
+        ]),
+        PerformanceNote.aggregate([
+          { $match: { employee: { $in: employeeIds } } },
+          { $group: { _id: "$employee", lastAt: { $max: "$createdAt" } } },
+        ]),
+        PerformanceReview.aggregate([
+          {
+            $match: {
+              employee: { $in: employeeIds },
+              status: { $in: FINAL_REVIEW_STATUSES },
+            },
+          },
+          { $group: { _id: "$employee", lastAt: { $max: "$updatedAt" } } },
+        ]),
+      ]);
+
+      const checkInMap = new Map<string, Date>();
+      for (const r of checkInAgg) checkInMap.set(String(r._id), r.lastAt);
+      const noteMap = new Map<string, Date>();
+      for (const r of noteAgg) noteMap.set(String(r._id), r.lastAt);
+      const reviewMap = new Map<string, Date>();
+      for (const r of reviewAgg) reviewMap.set(String(r._id), r.lastAt);
+
+      for (const emp of active) {
+        const id = String(emp._id);
+        const cadence = computeConversationCadence({
+          now,
+          hireDate: emp.hireDate as Date,
+          employeeStatus: (emp.status as string) ?? "active",
+          lastCheckInAt: checkInMap.get(id) ?? null,
+          lastNoteAt: noteMap.get(id) ?? null,
+          lastReviewAt: reviewMap.get(id) ?? null,
+        });
+
+        if (cadence.severity === "none") continue;
+
+        items.push({
+          id: `perf-overdue-${id}`,
+          type: "performance_conversation_overdue",
+          title: `No performance conversation in ${cadence.daysSince} days`,
+          description: `${emp.firstName} ${emp.lastName} — last documented conversation ${
+            cadence.lastConversationAt
+              ? `on ${new Date(cadence.lastConversationAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`
+              : "never recorded"
+          }`,
+          priority: cadence.severity,
+          link: `/dashboard/grow/check-ins?employee=${id}`,
+        });
+      }
+    }
+  } catch (error) {
+    console.error("Attention query failed (perf conversation guardrail):", error);
   }
 
   // Sort by priority (high first), then limit to 10

--- a/apps/platform/src/lib/perf-reviews/conversation-cadence.ts
+++ b/apps/platform/src/lib/perf-reviews/conversation-cadence.ts
@@ -1,0 +1,79 @@
+/**
+ * 90-day performance conversation guardrail.
+ *
+ * Pure detection logic for `docs/reqs/perf-reviews.md`:
+ *   "no employee goes more than 90 days without a structured, documented
+ *    conversation about their performance and development"
+ *
+ * A "structured, documented conversation" is any of:
+ *   - completed check-in        (CheckIn.completedAt)
+ *   - performance note           (PerformanceNote.createdAt)
+ *   - finalized perf review      (PerformanceReview with status in
+ *                                 {finalized, acknowledged, shared})
+ *
+ * New hires have a grace period equal to the threshold, so a 30-day-old
+ * employee with no conversations is not flagged.
+ */
+
+export const MEDIUM_THRESHOLD_DAYS = 90;
+export const HIGH_THRESHOLD_DAYS = 120;
+export const CONVERSATION_GRACE_PERIOD_DAYS = 90;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type CadenceSeverity = "none" | "medium" | "high";
+
+export interface CadenceInput {
+  now: Date;
+  hireDate: Date;
+  employeeStatus: string;
+  lastCheckInAt: Date | null;
+  lastNoteAt: Date | null;
+  lastReviewAt: Date | null;
+}
+
+export interface CadenceResult {
+  severity: CadenceSeverity;
+  daysSince: number;
+  lastConversationAt: Date | null;
+}
+
+function maxDate(dates: Array<Date | null>): Date | null {
+  let latest: Date | null = null;
+  for (const d of dates) {
+    if (!d) continue;
+    if (!latest || d.getTime() > latest.getTime()) latest = d;
+  }
+  return latest;
+}
+
+function daysBetween(later: Date, earlier: Date): number {
+  return Math.floor((later.getTime() - earlier.getTime()) / DAY_MS);
+}
+
+export function computeConversationCadence(input: CadenceInput): CadenceResult {
+  if (input.employeeStatus !== "active") {
+    return { severity: "none", daysSince: 0, lastConversationAt: null };
+  }
+
+  const lastConversationAt = maxDate([
+    input.lastCheckInAt,
+    input.lastNoteAt,
+    input.lastReviewAt,
+  ]);
+
+  const referenceDate = lastConversationAt ?? input.hireDate;
+  const daysSince = daysBetween(input.now, referenceDate);
+
+  // Grace period: new hires with no conversations yet get a free window
+  // equal to the threshold. After that, they start accruing like anyone else.
+  if (!lastConversationAt && daysSince < CONVERSATION_GRACE_PERIOD_DAYS) {
+    return { severity: "none", daysSince, lastConversationAt: null };
+  }
+
+  let severity: CadenceSeverity = "none";
+  if (daysSince >= HIGH_THRESHOLD_DAYS) severity = "high";
+  else if (daysSince >= MEDIUM_THRESHOLD_DAYS) severity = "medium";
+
+  return { severity, daysSince, lastConversationAt };
+}

--- a/apps/platform/src/tests/conversation-cadence.test.ts
+++ b/apps/platform/src/tests/conversation-cadence.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeConversationCadence,
+  CONVERSATION_GRACE_PERIOD_DAYS,
+  MEDIUM_THRESHOLD_DAYS,
+  HIGH_THRESHOLD_DAYS,
+} from "@/lib/perf-reviews/conversation-cadence";
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = new Date("2026-04-22T12:00:00Z");
+
+function daysAgo(days: number): Date {
+  return new Date(NOW.getTime() - days * DAY);
+}
+
+describe("computeConversationCadence", () => {
+  it("not flagged when a check-in was completed within 90 days", () => {
+    const result = computeConversationCadence({
+      now: NOW,
+      hireDate: daysAgo(365),
+      employeeStatus: "active",
+      lastCheckInAt: daysAgo(30),
+      lastNoteAt: null,
+      lastReviewAt: null,
+    });
+    expect(result.severity).toBe("none");
+    expect(result.daysSince).toBe(30);
+  });
+
+  it("not flagged when a performance note exists within 90 days", () => {
+    const result = computeConversationCadence({
+      now: NOW,
+      hireDate: daysAgo(400),
+      employeeStatus: "active",
+      lastCheckInAt: null,
+      lastNoteAt: daysAgo(45),
+      lastReviewAt: null,
+    });
+    expect(result.severity).toBe("none");
+  });
+
+  it("not flagged when a finalized review landed within 90 days", () => {
+    const result = computeConversationCadence({
+      now: NOW,
+      hireDate: daysAgo(800),
+      employeeStatus: "active",
+      lastCheckInAt: null,
+      lastNoteAt: null,
+      lastReviewAt: daysAgo(80),
+    });
+    expect(result.severity).toBe("none");
+  });
+
+  it("flags medium when nothing in 91 days", () => {
+    const result = computeConversationCadence({
+      now: NOW,
+      hireDate: daysAgo(500),
+      employeeStatus: "active",
+      lastCheckInAt: daysAgo(91),
+      lastNoteAt: null,
+      lastReviewAt: null,
+    });
+    expect(result.severity).toBe("medium");
+    expect(result.daysSince).toBe(91);
+  });
+
+  it("flags high when nothing in 120+ days", () => {
+    const result = computeConversationCadence({
+      now: NOW,
+      hireDate: daysAgo(500),
+      employeeStatus: "active",
+      lastCheckInAt: daysAgo(125),
+      lastNoteAt: null,
+      lastReviewAt: null,
+    });
+    expect(result.severity).toBe("high");
+    expect(result.daysSince).toBe(125);
+  });
+
+  it("new hire within grace period with no conversations is not flagged", () => {
+    const result = computeConversationCadence({
+      now: NOW,
+      hireDate: daysAgo(30),
+      employeeStatus: "active",
+      lastCheckInAt: null,
+      lastNoteAt: null,
+      lastReviewAt: null,
+    });
+    expect(result.severity).toBe("none");
+  });
+
+  it("employee hired 100 days ago with no conversations is flagged (grace expired)", () => {
+    const result = computeConversationCadence({
+      now: NOW,
+      hireDate: daysAgo(100),
+      employeeStatus: "active",
+      lastCheckInAt: null,
+      lastNoteAt: null,
+      lastReviewAt: null,
+    });
+    expect(result.severity).toBe("medium");
+    expect(result.daysSince).toBe(100);
+  });
+
+  it("terminated employee is never flagged", () => {
+    const result = computeConversationCadence({
+      now: NOW,
+      hireDate: daysAgo(500),
+      employeeStatus: "terminated",
+      lastCheckInAt: daysAgo(500),
+      lastNoteAt: null,
+      lastReviewAt: null,
+    });
+    expect(result.severity).toBe("none");
+  });
+
+  it("on_leave employee is never flagged", () => {
+    const result = computeConversationCadence({
+      now: NOW,
+      hireDate: daysAgo(500),
+      employeeStatus: "on_leave",
+      lastCheckInAt: daysAgo(500),
+      lastNoteAt: null,
+      lastReviewAt: null,
+    });
+    expect(result.severity).toBe("none");
+  });
+
+  it("picks most recent among check-in, note, review (tie-break test)", () => {
+    const result = computeConversationCadence({
+      now: NOW,
+      hireDate: daysAgo(800),
+      employeeStatus: "active",
+      lastCheckInAt: daysAgo(95),
+      lastNoteAt: daysAgo(30),
+      lastReviewAt: daysAgo(200),
+    });
+    expect(result.severity).toBe("none");
+    expect(result.daysSince).toBe(30);
+  });
+
+  it("thresholds are exported constants", () => {
+    expect(MEDIUM_THRESHOLD_DAYS).toBe(90);
+    expect(HIGH_THRESHOLD_DAYS).toBe(120);
+    expect(CONVERSATION_GRACE_PERIOD_DAYS).toBe(90);
+  });
+});

--- a/docs/reqs/perf-reviews.md
+++ b/docs/reqs/perf-reviews.md
@@ -1,0 +1,297 @@
+# Performance Reviews
+
+> Ascenta | Grow | Performance System | Performance Reviews
+> Process Flow, Review Categories, Research Foundation, and System Connections
+
+## Overview
+
+Performance Reviews in Ascenta are embedded within a continuous performance system — not a standalone annual event. Reviews combine ongoing check-ins, mid-year reviews, and annual reviews; require employee self-assessment first; enforce competency-anchored behavioral rating scales; and produce documented development plans. Categories are intentionally broad to fit any company, with Strategy Studio populating the Culture and Values Alignment category per organization.
+
+---
+
+## Design Principles (Research Foundation)
+
+### Six Structural Failures Ascenta Solves
+
+- [x] **Solve annual-only cadence** — embed reviews within a continuous system of ongoing check-ins, mid-year reviews, and annual reviews working together (not annual-only) — *`REVIEW_TYPES` includes annual, mid_year, ninety_day, custom; period selector in ReviewsPanel*
+- [!] **Solve backward-looking design** — every review is 40% retrospective and 60% forward-looking, covering goals achieved, development priorities, and specific support and commitments for the next period — **PARTIAL: dev plan captures forward-looking fields, but no structural enforcement of 40/60 split or dedicated forward-looking questions in category forms (#52)**
+- [x] **Solve manager-only ratings without data** — supplement manager judgment with multi-source data: self-assessments, continuous feedback records, goal completion data, and peer input; Ascenta surfaces all automatically — *evidence panel in ManagerAssessmentForm surfaces goals, check-ins, performance notes*
+- [x] **Solve absence of employee voice** — require employee self-assessment first and include two-way Reflect conversations as infrastructure — *SelfAssessmentPanel; 403 gate enforced in API; Reflect tracked in #26*
+- [x] **Solve missing development plans** — every review must include a documented development plan with specific actions, timelines, and manager commitments (mandatory, not optional) — *DevelopmentPlanForm is a required step before finalization*
+- [x] **Solve bell curve calibration** — use competency-anchored rating scales with behavioral descriptors; no forced distribution or normative curves — *5-point RATING_SCALE; no distribution enforcement*
+
+### Eight Research-Validated Practices Built In
+
+- [!] **Continuous feedback embedded with formal reviews** — check-ins, Reflect conversations, and coaching logs all feed directly into the review — **PARTIAL: check-in summaries and performance notes are pulled; Reflect not yet built (#26); coaching C&A audit logs not specifically surfaced**
+- [x] **Employee self-assessment completed first** — manager cannot begin their assessment until the employee has submitted theirs — *403 returned by `/api/grow/reviews/[id]` PATCH when selfAssessment.status !== "submitted"*
+- [x] **Goal linkage to strategic priorities** — automatic via Strategy Studio alignment; reviews without explicit goal-to-strategy connections cannot be defended or used for talent planning — *startPerformanceReviewTool pulls aligned goals and strategy goals; foundation data included*
+- [!] **Strengths-forward feedback approach** — dedicated Employee Strengths section in every review framework — **NOT IMPLEMENTED as dedicated section: no standalone Employee Strengths field in self-assessment or manager assessment forms (#52)**
+- [!] **Competency-anchored rating scales** — five-point scale with clear behavioral definitions at each level (no numeric scales without anchors) — **PARTIAL: 5-point scale exists with labels/descriptions, but anchors are generic across all categories — not per-competency (#54)**
+- [x] **Documented development plans attached to every review** — mandatory section, not optional add-on — *DevelopmentPlanForm required; review cannot be finalized without it*
+- [x] **Manager as coach, not evaluator** — language of coaching, not judgment; review framed as a coaching conversation — *guided prompts use coaching-oriented language; "Notes" framing vs judgment language*
+- [x] **Multi-source data in the preparation phase** — gather key achievements, performance metrics, attendance, peer/client feedback, and check-in notes before any review conversation — *evidence panel surfaces goals, check-ins, performance notes in ManagerAssessmentForm*
+
+### Question Ownership
+
+- [x] **HR owns the question framework** — questions are standardized frameworks developed by HR, grounded in the organization's competency model and strategic goals — *guided prompts hardcoded in `performance-review-categories.ts`, not user-authored*
+- [x] **Managers do not write their own questions** — producing wildly inconsistent evaluation criteria, reinforcing bias, and making calibration across teams impossible
+- [x] **Employees do not write their own questions** — creates selection bias toward areas where they feel confident
+- [x] **Shared framework, both parties respond to same questions** — built by HR, delivered to both, employee completes portion first and independently — *same REVIEW_CATEGORY_KEYS used in both SelfAssessmentForm and ManagerAssessmentForm*
+- [x] **Correct sequence enforced** — employee self-assessment opens first; manager cannot begin their assessment until the employee has submitted theirs; Reflect conversation surfaces and addresses gaps between self- and manager assessments — *403 gate enforced; Reflect step pending #26 and #57*
+
+---
+
+## Review Cadence: Three-Tier Model
+
+- [!] **Ongoing check-ins every two weeks** — continuous feedback cadence feeding into formal reviews — **PARTIAL: Check-ins module exists and data feeds review evidence; no cadence enforcement or "2-week" guardrail**
+- [!] **Formal mid-year review** — assesses goal progress and adjusts development priorities — **PARTIAL: `mid_year` in REVIEW_TYPES schema; period selector shows H1/H2 but not "mid_year" label explicitly**
+- [x] **Annual review** — venue for compensation decisions, formal promotion considerations, year-over-year development progress, and organizational talent calibration — *"annual" option in period selector*
+- [!] **90-Day review for new hires** — precedes the cycle and establishes baseline; retention and alignment tool (not a rating event); verifies role fit, addresses gaps in onboarding before they become habits, establishes manager-employee relationship foundation, confirms goal alignment, and documents early development needs — **PARTIAL: `ninety_day` in REVIEW_TYPES schema but not exposed in period selector UI; auto-trigger for new hires tracked in #46**
+- [x] **Guardrail: no employee goes more than 90 days without a structured, documented conversation about their performance and development** — *surfaced as `performance_conversation_overdue` alert on HR dashboard via `/api/dashboard/attention`; medium at 90d, high at 120d; counts completed check-ins, performance notes, and finalized reviews*
+
+---
+
+## Performance Review Process Flow (8 Steps + Reporting)
+
+### Step 1 — Review Initiation
+
+- [ ] **HR configures review cycle** — period, cadence, and participants — **NOT IMPLEMENTED in UI: ReviewCycle schema and API exist (`/api/grow/review-cycles`) but no HR-facing UI to create/manage cycles (#46)**
+- [x] **System auto-pulls supporting data** — aligned goals, strategic pillar tags, department focus areas, check-in notes, Reflect summaries, and coaching logs — *`startPerformanceReviewTool` pulls goals, check-ins, performance notes, foundation data, strategy goals*
+
+### Step 2 — Employee Self-Assessment (Completed First)
+
+- [x] **Employee self-assessment opens first** — employee rates self across all review categories using guided prompts — *SelfAssessmentPanel shows employee their pending reviews; SelfAssessmentForm has all 10 categories*
+- [!] **Goal completion, Reflect entries, and strategy alignment auto-populated** into the self-assessment — **PARTIAL: auto-population exists in v1 chat flow; v2 SelfAssessmentForm starts blank with no pre-populated goal data or Reflect entries**
+- [ ] **Includes strengths narrative, development priorities, and support needs** — **NOT IMPLEMENTED: SelfAssessmentForm has only generic "Notes" and "Specific Examples" per category — no dedicated strengths narrative, development priorities, or "support needed from manager" fields (#52)**
+- [x] **Self-assessment must be submitted before manager can begin** — hard gate — *API returns 403 if selfAssessment.status !== "submitted" when manager tries to save*
+
+### Step 3 — Manager Assessment
+
+- [x] **Manager must review employee's self-assessment before completing their own** — *employee's self-assessment sections shown as read-only reference panel in each CategorySectionCard*
+- [x] **Manager rates across same categories** using competency-anchored 1-to-5 scale — *same REVIEW_CATEGORY_KEYS; LikertScale 1–5*
+- [!] **Supporting documentation required** — check-in notes, coaching logs, metrics, goal data must accompany each rating — **PARTIAL: evidence panel present and evidence auto-surfaced; however submission is allowed with zero evidence tagged — no enforcement (#50)**
+
+### Step 4 — AI-Assisted Review Drafting
+
+- [!] **AI generates narrative review language** tied to strategic pillars and values — **PARTIAL: `generateReviewDraftTool` exists in v1 chat flow; v2 structured category flow has no AI narrative generation step (#55)**
+- [ ] **Sidebar displays which strategic priorities the employee ladders to** during drafting — **NOT IMPLEMENTED in v2 flow: strategic priorities sidebar exists in v1 working doc only (#55)**
+
+### Step 5 — Manager Finalizes Review
+
+- [!] **Manager edits AI-drafted language** and adds specific examples and context — **PARTIAL: editing exists in v1 PerformanceReviewForm; v2 flow goes directly from manager assessment → dev plan with no narrative editing step (#55)**
+- [!] **Manager confirms strategic alignment narrative** and attaches supporting documentation — **PARTIAL: strategic alignment field in v1 only; v2 dev plan has no strategic alignment confirmation (#55)**
+
+### Step 6 — Reflect Conversation
+
+- [ ] **Manager and employee discuss review in structured two-way dialogue** — **NOT IMPLEMENTED: Reflect module not yet built (#26); no Reflect step in review lifecycle (#57)**
+- [x] **Self-assessment and manager ratings compared side-by-side** during the Reflect conversation — *AcknowledgmentView shows side-by-side comparison of all 10 categories for both assessments*
+
+### Step 7 — Employee Acknowledgment
+
+- [x] **Employee signs to confirm receipt** (agreement not required) — *AcknowledgmentView: "Sign Off →" button sets status to "acknowledged"; confirmation copy reads "confirms you have reviewed and understand this assessment"*
+- [ ] **Option to add written response** from employee during acknowledgment — **NOT IMPLEMENTED: no textarea for employee written response in AcknowledgmentView (#49)**
+
+### Step 8 — Development Plan and Next Period Goals
+
+- [x] **Development plan with specific actions, timelines, and manager commitments** produced as part of review — *DevelopmentPlanForm: areas of improvement (area/actions/timeline/owner), manager commitments, next review date*
+- [ ] **Goals carry forward or are newly created from strategic pillar context** for the next period — **NOT IMPLEMENTED: no goal creation/carry-forward step after review finalization (#56)**
+
+### Alignment Reporting — Canopy / Vantage
+
+- [ ] **Category averages, strategic alignment gaps, capability needs, and trend data** feed into HR analytics and leadership dashboards — **NOT IMPLEMENTED: tracked in #47**
+
+---
+
+## Five Core Review Sections
+
+Every Ascenta performance review must contain these five structural sections:
+
+- [!] **1. Goal Achievement and Strategic Alignment** — primary measurement section; goals connected to organizational strategic plan, team objectives, and employee job description; covers three goal types (job description goals = ongoing accountabilities, project goals = time-bound objectives, behavioral goals = how work is accomplished); documents goal progress, names aiding/impeding factors, and establishes new goals for next period — **PARTIAL: goals pulled in v1 flow; v2 category forms have no dedicated Goal Achievement section; new goals for next period not built (#52)**
+- [!] **2. Core Competencies by Role, Measured With Behavioral Anchors** — base competencies: quality of work, quantity of work, dependability, interpersonal skills, initiative, adaptability, decision-making; for supervisory roles add planning and organization, leadership, conflict resolution, team development; every competency rating supported by at least one specific behavioral example from the review period; rating scale uses behavioral definitions at each level (not numeric without anchors) — **PARTIAL: 10 categories cover these competencies; behavioral anchors are generic not per-competency (#54); evidence optional not required (#50)**
+- [ ] **3. Employee Strengths and Documented Contributions** — dedicated section documenting what the employee did well, specific contributions exceeding expectations, recognition-worthy behaviors aligned to organizational values; captures the "how" behind the "what" (collaborative contributions, creative problem-solving, positive impact on culture); primary input to compensation and promotion decisions — **NOT IMPLEMENTED as dedicated section: no standalone strengths section in either self-assessment or manager assessment forms (#52)**
+- [x] **4. Development Plan With Specific Actions and Manager Commitments** — mandatory section; includes areas showing improvement since last review, areas requiring attention with specific actions identified, on-the-job activities or outside programs that would build capability, and a timeline with accountabilities for both employee and manager — *DevelopmentPlanForm fully implements this with areas/actions/timeline/owner/manager commitments/next review date*
+- [!] **5. Employee Self-Assessment and Formal Acknowledgment** — self-assessment asks employee to reflect on own goal progress, identify proudest accomplishments, name areas to improve, articulate development priorities for next period; review concludes with formal acknowledgment (signature confirms receipt, not agreement) — **PARTIAL: 10-category self-assessment and acknowledgment sign-off both exist; dedicated prompts for accomplishments/development priorities/support needs missing (#52)**
+
+---
+
+## Rating Scale (Five-Point, Competency-Anchored)
+
+- [x] **Level 1 — Improvement Needed** — behavioral anchors defined per competency — *label + generic description exists in RATING_SCALE; per-competency anchors not yet defined (#54)*
+- [x] **Level 2 — Developing** — behavioral anchors defined per competency — *same note as above*
+- [x] **Level 3 — Meets Expectations** — behavioral anchors defined per competency — *same note as above*
+- [x] **Level 4 — Exceeds Expectations** — behavioral anchors defined per competency — *same note as above*
+- [x] **Level 5 — Exceptional** — behavioral anchors defined per competency — *same note as above*
+- [x] **No forced distribution or bell curve calibration** — ratings are competency-anchored with behavioral descriptors at each level — *no distribution enforcement in code*
+- [ ] **Overall rating calculated from category averages** — maps to the five-point scale — **NOT IMPLEMENTED: no aggregation or display of overall rating from category averages (#51)**
+
+---
+
+## Ten Review Categories
+
+Each category contains dropdown subcategories, embedded competencies, and guided prompts for managers.
+
+### 1. Job Knowledge and Technical Competence
+
+- [x] **Definition** — ability to perform the role effectively using relevant skills, systems, and professional expertise — *shown in CategorySectionCard*
+- [!] **Subcategories** — technical skills related to the job, industry knowledge and best practices, understanding of tools/systems/technology, application of professional expertise, accuracy of work product — **PARTIAL: data exists in `performance-review-categories.ts` but subcategories are not rendered in the form UI (#53)**
+- [!] **Embedded competencies** — demonstrates strong understanding of job responsibilities; maintains knowledge of relevant tools, systems, and processes; applies technical skills effectively in daily work; maintains awareness of industry standards or best practices; uses technology and systems effectively — **PARTIAL: data exists but not rendered in UI (#53)**
+- [x] **Guided prompts** — "Does the employee understand the role and responsibilities?" / "Do they use required tools correctly?" / "Do they apply expertise to solve problems?" — *rendered as italic bullet list in CategorySectionCard*
+- [!] **Competency alignment** — Business Acumen and Technical Expertise — **PARTIAL: not stored in current categories data structure; not shown in UI**
+
+### 2. Quality of Work
+
+- [x] **Definition** — produces accurate, thorough, and reliable work that meets organizational standards
+- [!] **Subcategories** — accuracy and attention to detail, thoroughness and completeness, work standards and consistency, error prevention — **PARTIAL: data exists, not rendered in UI (#53)**
+- [!] **Embedded competencies** — accuracy and attention to detail; completeness and reliability of work; consistency of performance; adherence to professional standards; minimizes errors and rework — **PARTIAL: data exists, not rendered in UI (#53)**
+- [x] **Guided prompts** — "Does the employee produce dependable work?" / "Do they maintain quality standards?" / "Do they complete tasks correctly the first time?"
+- [x] **Legal defensibility note** — flagged as one of the most legally defensible review categories due to its objective, evidence-based nature — *noted in categories.ts comment*
+
+### 3. Productivity and Time Management
+
+- [x] **Definition** — manages workload effectively and completes responsibilities in a timely manner
+- [!] **Subcategories** — work output, meeting deadlines, work prioritization, efficiency and workflow management, time management — **PARTIAL: data exists, not rendered in UI (#53)**
+- [!] **Embedded competencies** — meets deadlines and commitments; prioritizes work effectively; maintains appropriate work pace; demonstrates efficient use of time; manages workload independently — **PARTIAL: data exists, not rendered in UI (#53)**
+- [x] **Guided prompts** — "Does the employee complete work within expected timeframes?" / "Do they manage competing priorities?" / "Do they use time productively?"
+- [!] **Competency alignment** — Utilization and Performance Output — **PARTIAL: not stored or shown**
+
+### 4. Communication
+
+- [x] **Definition** — communicates information clearly, professionally, and effectively with others
+- [!] **Subcategories** — verbal communication, written communication, listening skills, clarity of messaging, responsiveness — **PARTIAL: data exists, not rendered in UI (#53)**
+- [!] **Embedded competencies** — communicates clearly and respectfully; demonstrates strong listening skills; shares relevant information with stakeholders; writes professional and effective communications; responds appropriately and timely — **PARTIAL: data exists, not rendered in UI (#53)**
+- [x] **Guided prompts** — "Does the employee communicate clearly?" / "Do they provide timely updates?" / "Do they maintain professional communication?"
+- [!] **Competency alignment** — Communication — **PARTIAL: not stored or shown**
+
+### 5. Collaboration and Interpersonal Effectiveness
+
+- [x] **Definition** — works effectively with others and contributes positively to team success
+- [!] **Subcategories** — team collaboration, respect and professionalism, relationship building, conflict resolution, stakeholder engagement — **PARTIAL: data exists, not rendered in UI (#53)**
+- [!] **Embedded competencies** — demonstrates respect for colleagues; contributes to team goals; builds positive working relationships; supports collaboration across teams; resolves disagreements professionally — **PARTIAL: data exists, not rendered in UI (#53)**
+- [x] **Guided prompts** — "Does the employee contribute positively to the team?" / "Do they support coworkers?" / "Do they collaborate effectively?"
+- [!] **Competency alignment** — Relationship Management and Consultation — **PARTIAL: not stored or shown**
+
+### 6. Initiative and Problem Solving
+
+- [x] **Definition** — demonstrates ownership of work and proactively addresses challenges
+- [!] **Subcategories** — initiative and ownership, problem identification, decision making, continuous improvement, creativity and innovation — **PARTIAL: data exists, not rendered in UI (#53)**
+- [!] **Embedded competencies** — takes initiative to address challenges; identifies opportunities for improvement; uses sound judgment in decision making; demonstrates critical thinking; suggests innovative solutions — **PARTIAL: data exists, not rendered in UI (#53)**
+- [x] **Guided prompts** — "Does the employee solve problems independently?" / "Do they contribute ideas?" / "Do they take ownership of outcomes?"
+- [!] **Competency alignment** — Critical Evaluation and Leadership — **PARTIAL: not stored or shown**
+
+### 7. Professionalism and Accountability
+
+- [x] **Definition** — demonstrates reliability, integrity, and adherence to organizational standards
+- [!] **Subcategories** — reliability and dependability, attendance and punctuality, ethical conduct, compliance with policies, responsibility for results — **PARTIAL: data exists, not rendered in UI (#53)**
+- [!] **Embedded competencies** — demonstrates dependability and reliability; maintains punctuality and attendance; accepts responsibility for outcomes; follows policies and procedures; demonstrates ethical behavior — **PARTIAL: data exists, not rendered in UI (#53)**
+- [x] **Guided prompts** — "Does the employee behave professionally?" / "Do they follow policies?" / "Do they take accountability for work?"
+- [!] **Competency alignment** — Ethical Practice and Policy Compliance — **PARTIAL: not stored or shown**
+
+### 8. Leadership and Influence
+
+- [x] **Definition** — demonstrates behaviors that positively influence others and contribute to organizational success (applicable to all employees, not just managers)
+- [!] **Subcategories** — leadership potential, mentoring and coaching others, influencing positive outcomes, decision making, strategic thinking — **PARTIAL: data exists, not rendered in UI (#53)**
+- [!] **Embedded competencies** — demonstrates leadership behaviors; supports and mentors colleagues; encourages collaboration and engagement; demonstrates confidence in decision making; positively influences team culture — **PARTIAL: data exists, not rendered in UI (#53)**
+- [x] **Guided prompts** — "Does the employee demonstrate leadership potential?" / "Do they support the growth of others?" / "Do they positively influence the team?"
+- [!] **Competency alignment** — Leadership and Navigation — **PARTIAL: not stored or shown**
+
+### 9. Learning and Development
+
+- [x] **Definition** — demonstrates commitment to continuous improvement and professional growth
+- [!] **Subcategories** — skill development, training completion, professional certifications, learning new responsibilities, career development effort — **PARTIAL: data exists, not rendered in UI (#53)**
+- [!] **Embedded competencies** — participates in training or development opportunities; demonstrates willingness to learn new skills; applies new knowledge to work; seeks feedback and coaching; demonstrates adaptability to change — **PARTIAL: data exists, not rendered in UI (#53)**
+- [x] **Guided prompts** — "Does the employee pursue growth opportunities?" / "Do they learn new skills?" / "Do they adapt to new expectations?"
+- [!] **Competency alignment** — Continuous Learning and Talent Management — **PARTIAL: not stored or shown**
+
+### 10. Culture and Values Alignment
+
+- [x] **Definition** — demonstrates behaviors that align with the organization's mission, values, and culture; unique to each organization
+- [!] **Subcategories (customizable per organization from Strategy Studio)** — integrity, respect, accountability, service orientation, team support — **PARTIAL: default subcategories exist; Strategy Studio customization not yet wired to this category at the form level (#53)**
+- [!] **Embedded competencies** — demonstrates respect and integrity; treats others fairly and professionally; supports a positive workplace culture; demonstrates commitment to organizational values; contributes positively to the work environment — **PARTIAL: data exists, not rendered in UI (#53)**
+- [x] **Guided prompts** — "Does the employee reflect company values in daily work?" / "Do they contribute positively to the culture?"
+- [!] **Strategy Studio connection** — mission, vision, core values, and non-negotiable behaviors entered in Strategy Studio populate the subcategories and prompts here — **PARTIAL: foundation data (mission/values) pulled into review context in v1 flow; live subcategory population from Strategy Studio values not implemented**
+
+---
+
+## Nine Core Areas to Measure
+
+The minimum set of dimensions necessary for a complete, defensible, and developmentally useful evaluation.
+
+- [x] **A. Quality of Work** — does the employee complete work accurately, thoroughly, and to the required standard? Does output reflect attention to detail? Is rework required frequently or rarely? — *quality_of_work category*
+- [x] **B. Quantity of Work and Productivity** — does the employee meet expected output targets? Does workload management reflect appropriate prioritization? Is volume consistent with role requirements? — *productivity category*
+- [x] **C. Goal Achievement** — did the employee achieve goals established at the start of the review period? What percentage of goals were met, exceeded, or not met? What factors contributed to each outcome? — *covered via goals evidence; dedicated Goal Achievement section pending #52*
+- [x] **D. Dependability** — how reliable is the employee in completing assignments, meeting deadlines, and being present? Do others depend on them with confidence? Is attendance and punctuality consistent? — *professionalism category*
+- [x] **E. Interpersonal Skills and Teamwork** — does the employee work effectively with peers, supervisors, and direct reports? Do they share information, resolve conflicts, and contribute to a positive team environment? — *collaboration category*
+- [x] **F. Initiative and Problem Solving** — does the employee work independently? Do they identify problems before being told? Do they look for more efficient or effective approaches to their work? — *initiative category*
+- [x] **G. Adaptability** — is the employee able to adjust effectively to changing priorities, new information, or unexpected challenges? Do they remain productive through change? — *covered in learning_development and professionalism categories*
+- [x] **H. Communication** — does the employee communicate clearly and appropriately in writing, verbally, and in listening? Are they effective at sharing information across levels and functions? — *communication category*
+- [x] **I. Development and Growth** — has the employee made progress on their development plan since the last review? Have they pursued learning opportunities? Are they growing in their role? — *learning_development category + DevelopmentPlanForm*
+
+---
+
+## Five Principles for Effective Review Questions
+
+Governing rules for how Ascenta builds guided prompts for every review category.
+
+- [x] **1. Tie every question to measurable or observable behavior** — reference specific behaviors or outcomes, never character judgments; e.g., "Did the employee demonstrate initiative in identifying process improvements?" not "Is the employee a self-starter?"; questions must be answerable with evidence, not impression — *all guided prompts use behavioral language*
+- [x] **2. Align questions to the job description and strategic goals** — review criteria align with each team member's job description and organizational goals; questions not connected to documented responsibilities cannot be used for compensation or disciplinary purposes; every question answerable in the context of the specific role — *categories align to job competencies; strategy goals pulled in*
+- [!] **3. Use behavioral anchors for every rating level** — define what "meets expectations," "exceeds expectations," and "needs improvement" look like behaviorally for each competency; without anchors, different managers rate the same behavior differently — **PARTIAL: 5-point scale exists with generic labels; per-competency behavioral anchors not defined (#54)**
+- [x] **4. Include forward-looking questions, not only backward-looking** — every review includes at least one question focused on the next period (e.g., "What are the major goals and accountabilities for the next review period?" / "What development actions would strengthen performance in the coming months?") — *DevelopmentPlanForm captures forward-looking actions; next-period goal creation pending #56*
+- [!] **5. Build in two-way questions that invite employee voice** — at minimum, every review includes: "What support do you need from your manager in the next period?" and "What obstacles have made it harder to meet your goals?" — **PARTIAL: SelfAssessmentForm has Notes/Examples per category but no dedicated "support needed" or "obstacles" fields (#52)**
+
+---
+
+## Supporting Documentation Requirement
+
+- [!] **Managers must provide evidence for each category rating** — no unsupported ratings allowed — **PARTIAL: evidence panel present and data auto-surfaced; submission is allowed without any evidence tagged (#50)**
+- [x] **Evidence auto-surfaced from the Performance System** — check-in notes from ongoing conversations, coaching logs from Coaching and Corrective Action module, performance metrics tied to goal key results, and goal completion summaries from Goals module — *evidence endpoint `/api/grow/reviews/[id]/evidence` returns goals, check-ins, performance notes grouped and selectable*
+- [x] **Legal defensibility** — evidence-based structure ensures ratings are grounded in observable, documented performance rather than recency bias or subjective impression — *evidence tagging persisted per category rating on review record*
+
+---
+
+## Cross-Module Connections Within Grow
+
+- [x] **Goals** — completion data feeds review evidence — *`startPerformanceReviewTool` fetches employee goals for the period; evidence panel surfaces goals for manager tagging*
+- [x] **Check-ins** — notes auto-populated as supporting evidence — *check-in summaries pulled in v1 tool; check-in records surfaced in evidence panel*
+- [ ] **Reflect** — two-way summaries feed the review narrative — **NOT IMPLEMENTED: Reflect module not yet built (#26); not pulled into review context or evidence (#57)**
+- [!] **Coaching and Corrective Action** — logs used as required documentation — **PARTIAL: PerformanceNote records pulled as evidence; formal coaching workflow audit logs from Corrective Action module not specifically surfaced**
+
+### External Module Connections
+
+- [x] **Strategy Studio (Foundation Layer)** — mission, vision, and values flow into the Culture and Values Alignment category and all guided prompts; strategic priorities and department focus areas populate goal alignment checks within the review — *foundation data (mission/values) and strategy goals pulled in startPerformanceReviewTool; live subcategory population from Strategy Studio values pending*
+- [ ] **Leadership Library (Manager Guidance)** — evaluation guides, rating calibration resources, review writing best practices, strategic thinking guides, cascading conversation starters, and sample goal prompts available to managers — **NOT IMPLEMENTED: tracked in #26**
+- [ ] **Learning and Development: Culture Gym** — development plans created from review outcomes and capability gaps identified in alignment reporting; shaped by company mission, vision, and values — **NOT IMPLEMENTED**
+- [!] **Coaching and Corrective Action** — tied to goal and review outcomes; development plans aligned to strategic capability needs; coaching logs serve as required supporting documentation for review ratings — **PARTIAL: performance notes surfaced; formal C&A workflow logs not directly connected**
+
+---
+
+## Reference
+
+### Research Data Points (used in-product rationale and HR education)
+
+| Statistic | Context |
+|---|---|
+| 71% | of companies conduct reviews on annual-only basis despite insufficiency |
+| 62% | of employees believe performance reviews are ineffective due to lack of clear feedback and follow-up |
+| 210 hrs | average time managers spend per year preparing annual reviews |
+| 60% | of HR professionals report managers lack data-driven insights for effective reviews |
+| 60%+ | of a performance rating attributable to individual manager idiosyncrasies |
+| 4.2x | organizations focused on employee performance outperform peers |
+| ~30% | higher revenue growth in performance-focused organizations |
+| 5 pts | lower attrition in performance-focused organizations |
+| 39% / 44% | more effective at attracting / retaining talent with continuous feedback |
+| 74% | of organizations have shifted to some form of ongoing feedback |
+| 87% | of HR leaders say annual reviews alone are insufficient |
+| 94% | of employees prefer real-time feedback |
+| 14.9% | lower turnover rates with continuous feedback |
+| 24% / 40% | outperformance and higher engagement with continuous feedback |
+| 47% | of companies with regular reviews include self-appraisals |
+| 91% / 14% | link individual goals to business priorities / confident it drives business value |
+| 8.9% / 12.5% | more profitable / productive when feedback focuses on strengths |
+| 31% | lower turnover when continuous feedback and development emphasized |
+| 72% | of workers do not trust their organization's performance management process |
+| 26% | of orgs believe their managers are highly effective at enabling performance |
+| 54% | of executives rank coaching and mentoring first in what managers should strengthen |
+| 3.6x | more engaged when new hires receive structured feedback in first 90 days |
+| 69% | of employees more likely to stay three years with great onboarding |
+| 12% | of employees believe employers do a great job with onboarding |
+| 54% | of voluntary departures occur in first six months |

--- a/docs/superpowers/specs/2026-04-22-perf-reviews-90-day-guardrail-design.md
+++ b/docs/superpowers/specs/2026-04-22-perf-reviews-90-day-guardrail-design.md
@@ -1,0 +1,98 @@
+# 90-Day Performance Conversation Guardrail
+
+**Source requirement:** `docs/reqs/perf-reviews.md` line 50 (Review Cadence: Three-Tier Model)
+
+> Guardrail: no employee goes more than 90 days without a structured, documented conversation about their performance and development
+
+## Goal
+
+Surface a visible, actionable alert on the HR dashboard whenever an active employee has gone 90+ days without any structured performance conversation. This is a *soft guardrail* — a warning surface, not a hard block on other actions.
+
+## What counts as a "structured, documented conversation"
+
+Any one of the following, most recent `completedAt` / `createdAt` wins:
+
+1. **Completed check-in** — `CheckIn.completedAt != null`
+2. **Performance note** — any `PerformanceNote` for the employee (types: observation, coaching, recognition)
+3. **Finalized performance review** — `PerformanceReview.finalizedAt != null` *or* `status in ("acknowledged", "finalized")`
+
+We intentionally exclude corrective actions (verbal, written warning, PIP) — those are remediation, not the "performance and development" conversations the guardrail targets.
+
+## Detection logic
+
+For each **active** employee (status `active`, not terminated or on leave):
+
+```
+lastConversationAt = max(
+  latestCompletedCheckInAt,
+  latestPerformanceNoteCreatedAt,
+  latestFinalizedReviewAt
+)
+
+daysSince = lastConversationAt ? (now - lastConversationAt) / 1day : (now - hireDate) / 1day
+
+if daysSince >= 90 → alert "performance_conversation_overdue"
+```
+
+Employees with no prior conversation and hired <90 days ago are **not** flagged (grace period during onboarding).
+
+## Where it surfaces
+
+Add a new item type to `/api/dashboard/attention`:
+
+```ts
+{
+  type: "performance_conversation_overdue",
+  priority: "high",
+  title: "No performance conversation in 90+ days",
+  description: "<Employee name> — last conversation <N> days ago",
+  href: "/dashboard/grow/check-ins?employee=<id>",
+  metadata: { employeeId, daysSince, lastConversationAt }
+}
+```
+
+`components/dashboard/needs-attention.tsx` already renders arbitrary alert types, so no UI changes are required.
+
+## Severity rules
+
+- 90–119 days since last conversation → `medium` priority
+- 120+ days → `high` priority
+
+## Scope — what's NOT in this PR
+
+- No email notifications (would be a separate feature)
+- No cron job (the alert is computed on-demand by the attention API)
+- No manager-facing in-app notification (notification-center stays as-is)
+- No hard enforcement (nothing blocks other workflows)
+
+## Testing strategy
+
+Unit tests against the new detection helper (`lib/perf-reviews/conversation-cadence.ts`):
+
+1. Employee with recent completed check-in within 90d → not flagged
+2. Employee with note within 90d but no check-in → not flagged
+3. Employee with finalized review within 90d → not flagged
+4. Employee with nothing in 91+ days → flagged, medium
+5. Employee with nothing in 120+ days → flagged, high
+6. Employee hired 30 days ago with nothing → not flagged (grace period)
+7. Employee hired 100 days ago with nothing → flagged (no grace)
+8. Inactive / terminated employee → not flagged regardless
+9. Tie-break: check-in 95 days ago, note 30 days ago → not flagged (note wins)
+
+Integration test: attention API returns the alert when fixtures match scenario #4.
+
+## File plan
+
+**New:**
+- `apps/platform/src/lib/perf-reviews/conversation-cadence.ts` — pure detection helper
+- `apps/platform/src/lib/perf-reviews/__tests__/conversation-cadence.test.ts` — unit tests
+
+**Modified:**
+- `apps/platform/src/app/api/dashboard/attention/route.ts` — aggregate latest conversation date per employee, emit alerts
+- `docs/reqs/perf-reviews.md` — check off line 50
+
+## Non-goals / YAGNI
+
+- No new schema fields. We compute `lastConversationAt` on the fly. If performance becomes an issue later, we can denormalize, but the company has <1000 employees — aggregation is fine.
+- No new endpoints. Piggybacks on existing attention API.
+- No per-employee toggle. The guardrail applies to all active employees uniformly.


### PR DESCRIPTION
## Summary

Closes the **Review Cadence: Three-Tier Model** guardrail from `docs/reqs/perf-reviews.md` (line 50):

> Guardrail: no employee goes more than 90 days without a structured, documented conversation about their performance and development.

Surfaces a new `performance_conversation_overdue` alert on the HR dashboard when an active employee has gone 90+ days without any structured performance conversation. A "conversation" is any completed check-in, performance note, or finalized performance review.

- **90–119 days** → medium priority
- **120+ days** → high priority
- New hires get a 90-day grace period
- Inactive / terminated / on-leave employees are never flagged

## Changes

- `apps/platform/src/lib/perf-reviews/conversation-cadence.ts` — pure detection helper
- `apps/platform/src/tests/conversation-cadence.test.ts` — 11 unit tests
- `apps/platform/src/app/api/dashboard/attention/route.ts` — wires the guardrail into the existing attention feed
- `docs/reqs/perf-reviews.md` — checks off the requirement

No new schema fields. The alert is computed on-demand from existing indexes — 3 parallel aggregations keyed on employee.

## Test plan

- [x] `pnpm test` — 99/99 (11 new)
- [x] `pnpm --filter=@ascenta/platform exec tsc --noEmit` — clean
- [x] `pnpm build` — clean
- [ ] Manually verify alert appears on HR dashboard `needs-attention` when an employee has no recent conversation (requires seeding / live data; `needs-attention.tsx` already renders arbitrary alert types)

## Notes

`pnpm lint` fails on both main and this branch because the monorepo's eslint configs haven't been migrated to flat config (ESLint 9). That's a pre-existing repo issue, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)