### PR TITLE
feat: My Organization Download (Plan module sub-project #5)

### DIFF
--- a/apps/platform/package.json
+++ b/apps/platform/package.json
@@ -18,6 +18,7 @@
     "@ascenta/types": "workspace:*",
     "@ascenta/ui": "workspace:*",
     "@hookform/resolvers": "^5.2.2",
+    "@react-pdf/renderer": "^4.5.1",
     "@vercel/analytics": "^1.6.1",
     "ai": "^6.0.49",
     "d3": "^7.9.0",

--- a/apps/platform/src/app/api/employees/[id]/organization-pdf/route.ts
+++ b/apps/platform/src/app/api/employees/[id]/organization-pdf/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import mongoose from "mongoose";
+import { assembleOrgSnapshot } from "@/lib/pdf/assemble-org-snapshot";
+import { renderOrgSnapshot } from "@/lib/pdf/render-org-snapshot";
+
+export const runtime = "nodejs";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+function slugify(s: string) {
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "");
+}
+
+export async function GET(_req: NextRequest, ctx: Ctx) {
+  try {
+    const { id } = await ctx.params;
+    if (!mongoose.isValidObjectId(id)) {
+      return NextResponse.json({ error: "Invalid id" }, { status: 404 });
+    }
+    const snapshot = await assembleOrgSnapshot(id);
+    const buffer = await renderOrgSnapshot(snapshot);
+    const filename = `${slugify(snapshot.employee.name) || "employee"}-organization-snapshot.pdf`;
+    return new Response(new Uint8Array(buffer), {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/not found/i.test(message)) {
+      return NextResponse.json({ error: message }, { status: 404 });
+    }
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/platform/src/components/plan/my-profile-tab.tsx
+++ b/apps/platform/src/components/plan/my-profile-tab.tsx
@@ -3,6 +3,7 @@
 import { useAuth } from "@/lib/auth/auth-context";
 import { FocusLayerSection } from "@/components/plan/focus-layer/focus-layer-section";
 import { ProfileEditSection } from "@/components/plan/profile/profile-edit-section";
+import { DownloadOrgSnapshotButton } from "@/components/plan/profile/download-org-snapshot-button";
 
 export function MyProfileTab() {
   const { user, loading } = useAuth();
@@ -27,11 +28,14 @@ export function MyProfileTab() {
 
   return (
     <div className="flex-1 overflow-y-auto p-6 space-y-6">
-      <header>
-        <h2 className="text-xl font-display font-bold">My Profile</h2>
-        <p className="text-sm text-muted-foreground">
-          {user.name} · {user.title} · {user.department}
-        </p>
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-display font-bold">My Profile</h2>
+          <p className="text-sm text-muted-foreground">
+            {user.name} · {user.title} · {user.department}
+          </p>
+        </div>
+        <DownloadOrgSnapshotButton employeeId={user.id} />
       </header>
 
       <section className="rounded-lg border p-6">

--- a/apps/platform/src/components/plan/profile/download-org-snapshot-button.tsx
+++ b/apps/platform/src/components/plan/profile/download-org-snapshot-button.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Button } from "@ascenta/ui/button";
+import { FileDown } from "lucide-react";
+
+interface Props {
+  employeeId: string;
+  size?: "sm" | "default";
+  label?: string;
+}
+
+export function DownloadOrgSnapshotButton({
+  employeeId,
+  size = "sm",
+  label = "Download My Organization Snapshot",
+}: Props) {
+  return (
+    <Button
+      variant="outline"
+      size={size}
+      onClick={() =>
+        window.open(`/api/employees/${employeeId}/organization-pdf`)
+      }
+    >
+      <FileDown className="size-4 mr-1" />
+      {label}
+    </Button>
+  );
+}

--- a/apps/platform/src/components/plan/profile/download-org-snapshot-button.tsx
+++ b/apps/platform/src/components/plan/profile/download-org-snapshot-button.tsx
@@ -3,27 +3,35 @@
 import { Button } from "@ascenta/ui/button";
 import { FileDown } from "lucide-react";
 
+type Size = "sm" | "default" | "icon" | "icon-sm";
+
 interface Props {
   employeeId: string;
-  size?: "sm" | "default";
+  size?: Size;
   label?: string;
+  iconOnly?: boolean;
 }
 
 export function DownloadOrgSnapshotButton({
   employeeId,
   size = "sm",
   label = "Download My Organization Snapshot",
+  iconOnly = false,
 }: Props) {
+  const ariaLabel = label;
+  const buttonSize: Size = iconOnly ? "icon-sm" : size;
   return (
     <Button
       variant="outline"
-      size={size}
+      size={buttonSize}
+      aria-label={ariaLabel}
+      title={ariaLabel}
       onClick={() =>
         window.open(`/api/employees/${employeeId}/organization-pdf`)
       }
     >
-      <FileDown className="size-4 mr-1" />
-      {label}
+      <FileDown className="size-4" />
+      {!iconOnly && <span className="ml-1">{label}</span>}
     </Button>
   );
 }

--- a/apps/platform/src/components/plan/profile/employee-profile-card.tsx
+++ b/apps/platform/src/components/plan/profile/employee-profile-card.tsx
@@ -8,6 +8,7 @@ import {
   DialogTrigger,
 } from "@ascenta/ui/dialog";
 import { ProfileCompletionBadge } from "./profile-completion-badge";
+import { DownloadOrgSnapshotButton } from "./download-org-snapshot-button";
 import { FocusLayerReadView } from "@/components/plan/focus-layer/focus-layer-read-view";
 
 interface Props {
@@ -87,10 +88,13 @@ function Body({ data }: { data: Snapshot }) {
                 Reports to: {employee.managerName}
               </p>
             </div>
-            <ProfileCompletionBadge
-              complete={completion.complete}
-              total={completion.total}
-            />
+            <div className="flex items-center gap-2">
+              <DownloadOrgSnapshotButton employeeId={employee.id} />
+              <ProfileCompletionBadge
+                complete={completion.complete}
+                total={completion.total}
+              />
+            </div>
           </div>
         </div>
       </header>

--- a/apps/platform/src/components/plan/profile/employee-profile-card.tsx
+++ b/apps/platform/src/components/plan/profile/employee-profile-card.tsx
@@ -88,8 +88,11 @@ function Body({ data }: { data: Snapshot }) {
                 Reports to: {employee.managerName}
               </p>
             </div>
-            <div className="flex items-center gap-2">
-              <DownloadOrgSnapshotButton employeeId={employee.id} />
+            <div className="flex items-center gap-2 shrink-0">
+              <DownloadOrgSnapshotButton
+                employeeId={employee.id}
+                iconOnly
+              />
               <ProfileCompletionBadge
                 complete={completion.complete}
                 total={completion.total}

--- a/apps/platform/src/lib/pdf/assemble-org-snapshot.ts
+++ b/apps/platform/src/lib/pdf/assemble-org-snapshot.ts
@@ -1,0 +1,182 @@
+import mongoose from "mongoose";
+import { connectDB } from "@ascenta/db";
+import { Employee } from "@ascenta/db/employee-schema";
+import { JobDescription } from "@ascenta/db/job-description-schema";
+import { FocusLayer } from "@ascenta/db/focus-layer-schema";
+import { CompanyFoundation } from "@ascenta/db/foundation-schema";
+
+export interface OrgSnapshotData {
+  generatedAt: Date;
+  employee: {
+    id: string;
+    name: string;
+    pronouns: string | null;
+    jobTitle: string;
+    department: string;
+    hireDate: Date;
+    photoBase64: string | null;
+  };
+  jobDescription: {
+    title: string;
+    roleSummary: string;
+    coreResponsibilities: string[];
+    competencies: string[];
+  } | null;
+  reportingLine: {
+    skipLevelName: string | null;
+    managerName: string | null;
+    directReportNames: string[];
+  };
+  team: Array<{ id: string; name: string; jobTitle: string; isSelf: boolean }>;
+  focusLayer: {
+    status: "confirmed";
+    responses: {
+      uniqueContribution: string;
+      highImpactArea: string;
+      signatureResponsibility: string;
+      workingStyle: string;
+    };
+  } | null;
+  foundation: {
+    mission: string | null;
+    vision: string | null;
+    coreValues: string[];
+  } | null;
+}
+
+type EmployeeDoc = {
+  _id: mongoose.Types.ObjectId;
+  firstName: string;
+  lastName: string;
+  jobTitle: string;
+  department: string;
+  managerName: string;
+  hireDate: Date;
+  jobDescriptionId?: mongoose.Types.ObjectId | null;
+  profile?: { pronouns?: string | null; photoBase64?: string | null };
+};
+
+const fullName = (e: { firstName: string; lastName: string }) =>
+  `${e.firstName} ${e.lastName}`;
+const norm = (s: string) => s.trim().toLowerCase();
+
+function parseValues(values: string | null | undefined): string[] {
+  if (!values || !values.trim()) return [];
+  return values
+    .split(/[,\n]/g)
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
+
+export async function assembleOrgSnapshot(
+  employeeId: string,
+): Promise<OrgSnapshotData> {
+  await connectDB();
+  if (!mongoose.isValidObjectId(employeeId)) {
+    throw new Error("Invalid employee id");
+  }
+  const me = (await Employee.findById(employeeId).lean()) as EmployeeDoc | null;
+  if (!me) throw new Error("Employee not found");
+
+  const [allEmployeesRaw, foundationDoc] = await Promise.all([
+    Employee.find({ status: "active" }).lean(),
+    CompanyFoundation.findOne({ status: "published" })
+      .lean()
+      .catch(() => null),
+  ]);
+  const allEmployees = allEmployeesRaw as unknown as EmployeeDoc[];
+
+  const byName = new Map<string, EmployeeDoc>(
+    allEmployees.map((e) => [norm(fullName(e)), e]),
+  );
+  const manager = me.managerName ? (byName.get(norm(me.managerName)) ?? null) : null;
+  const skip =
+    manager && manager.managerName
+      ? (byName.get(norm(manager.managerName)) ?? null)
+      : null;
+
+  const meName = norm(fullName(me));
+  const directReports = allEmployees
+    .filter((e) => norm(e.managerName ?? "") === meName)
+    .map((e) => fullName(e));
+
+  const team = allEmployees
+    .filter((e) => e.department === me.department)
+    .slice(0, 8)
+    .map((e) => ({
+      id: String(e._id),
+      name: fullName(e),
+      jobTitle: e.jobTitle ?? "",
+      isSelf: String(e._id) === String(me._id),
+    }));
+
+  let jd: OrgSnapshotData["jobDescription"] = null;
+  if (me.jobDescriptionId) {
+    const found = (await JobDescription.findById(me.jobDescriptionId).lean()) as {
+      title: string;
+      roleSummary: string;
+      coreResponsibilities?: string[];
+      competencies?: string[];
+    } | null;
+    if (found) {
+      jd = {
+        title: found.title,
+        roleSummary: found.roleSummary,
+        coreResponsibilities: found.coreResponsibilities ?? [],
+        competencies: found.competencies ?? [],
+      };
+    }
+  }
+
+  let focusLayer: OrgSnapshotData["focusLayer"] = null;
+  const fl = (await FocusLayer.findOne({ employeeId: me._id }).lean()) as {
+    status?: string;
+    responses?: OrgSnapshotData["focusLayer"] extends infer T
+      ? T extends { responses: infer R }
+        ? R
+        : never
+      : never;
+  } | null;
+  if (fl && fl.status === "confirmed" && fl.responses) {
+    focusLayer = {
+      status: "confirmed",
+      responses: fl.responses as NonNullable<
+        OrgSnapshotData["focusLayer"]
+      >["responses"],
+    };
+  }
+
+  const foundation = foundationDoc
+    ? {
+        mission:
+          (foundationDoc as { mission?: string | null }).mission?.trim() || null,
+        vision:
+          (foundationDoc as { vision?: string | null }).vision?.trim() || null,
+        coreValues: parseValues(
+          (foundationDoc as { values?: string | null }).values,
+        ),
+      }
+    : null;
+
+  return {
+    generatedAt: new Date(),
+    employee: {
+      id: String(me._id),
+      name: fullName(me),
+      pronouns: me.profile?.pronouns ?? null,
+      jobTitle: me.jobTitle,
+      department: me.department,
+      hireDate: me.hireDate,
+      photoBase64: me.profile?.photoBase64 ?? null,
+    },
+    jobDescription: jd,
+    reportingLine: {
+      skipLevelName: skip ? fullName(skip) : null,
+      managerName: manager ? fullName(manager) : null,
+      directReportNames: directReports,
+    },
+    team,
+    focusLayer,
+    foundation,
+  };
+}

--- a/apps/platform/src/lib/pdf/components/cover-section.tsx
+++ b/apps/platform/src/lib/pdf/components/cover-section.tsx
@@ -1,0 +1,30 @@
+import { View, Text, Image } from "@react-pdf/renderer";
+import { styles } from "../pdf-styles";
+import type { OrgSnapshotData } from "../assemble-org-snapshot";
+
+export function CoverSection({ data }: { data: OrgSnapshotData }) {
+  const { employee, generatedAt } = data;
+  return (
+    <View>
+      <View style={styles.accentBar} />
+      <View style={styles.coverRow}>
+        {employee.photoBase64 ? (
+          <Image src={employee.photoBase64} style={styles.photo} />
+        ) : null}
+        <View>
+          <Text style={styles.h1}>
+            {employee.name}
+            {employee.pronouns ? ` · ${employee.pronouns}` : ""}
+          </Text>
+          <Text style={styles.paragraph}>
+            {employee.jobTitle} · {employee.department}
+          </Text>
+          <Text style={styles.meta}>
+            Generated {generatedAt.toLocaleDateString()}
+          </Text>
+        </View>
+      </View>
+      <View style={styles.divider} />
+    </View>
+  );
+}

--- a/apps/platform/src/lib/pdf/components/focus-layer-section-pdf.tsx
+++ b/apps/platform/src/lib/pdf/components/focus-layer-section-pdf.tsx
@@ -1,0 +1,28 @@
+import { View, Text } from "@react-pdf/renderer";
+import { styles } from "../pdf-styles";
+import type { OrgSnapshotData } from "../assemble-org-snapshot";
+
+type Responses = NonNullable<OrgSnapshotData["focusLayer"]>["responses"];
+
+const PROMPT_LABELS: Array<[keyof Responses, string]> = [
+  ["uniqueContribution", "What you bring uniquely"],
+  ["highImpactArea", "Where you create the most impact"],
+  ["signatureResponsibility", "Responsibilities that shape the team"],
+  ["workingStyle", "How you prefer to work"],
+];
+
+export function FocusLayerSectionPdf({ data }: { data: OrgSnapshotData }) {
+  if (!data.focusLayer) return null;
+  const responses = data.focusLayer.responses;
+  return (
+    <View style={styles.section}>
+      <Text style={styles.h2}>Your Focus Layer</Text>
+      {PROMPT_LABELS.map(([key, label]) => (
+        <View key={key} style={{ marginBottom: 6 }}>
+          <Text style={[styles.paragraph, styles.bold]}>{label}</Text>
+          <Text style={styles.paragraph}>{responses[key]}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/apps/platform/src/lib/pdf/components/mission-anchor-section.tsx
+++ b/apps/platform/src/lib/pdf/components/mission-anchor-section.tsx
@@ -1,0 +1,32 @@
+import { View, Text } from "@react-pdf/renderer";
+import { styles } from "../pdf-styles";
+import type { OrgSnapshotData } from "../assemble-org-snapshot";
+
+export function MissionAnchorSection({ data }: { data: OrgSnapshotData }) {
+  if (!data.foundation) return null;
+  const { mission, vision, coreValues } = data.foundation;
+  if (!mission && !vision && coreValues.length === 0) return null;
+  return (
+    <View style={styles.section}>
+      <Text style={styles.h2}>How this connects to the organization</Text>
+      {mission && (
+        <Text style={styles.paragraph}>
+          <Text style={styles.bold}>Mission. </Text>
+          {mission}
+        </Text>
+      )}
+      {vision && (
+        <Text style={[styles.paragraph, { marginTop: 4 }]}>
+          <Text style={styles.bold}>Vision. </Text>
+          {vision}
+        </Text>
+      )}
+      {coreValues.length > 0 && (
+        <Text style={[styles.paragraph, { marginTop: 4 }]}>
+          <Text style={styles.bold}>Core values. </Text>
+          {coreValues.join(", ")}
+        </Text>
+      )}
+    </View>
+  );
+}

--- a/apps/platform/src/lib/pdf/components/reporting-line-section.tsx
+++ b/apps/platform/src/lib/pdf/components/reporting-line-section.tsx
@@ -1,0 +1,35 @@
+import { View, Text } from "@react-pdf/renderer";
+import { styles } from "../pdf-styles";
+import type { OrgSnapshotData } from "../assemble-org-snapshot";
+
+export function ReportingLineSection({ data }: { data: OrgSnapshotData }) {
+  const { reportingLine, employee } = data;
+  const layers: Array<{ label: string; value: string }> = [];
+  if (reportingLine.skipLevelName) {
+    layers.push({ label: "Skip-level", value: reportingLine.skipLevelName });
+  }
+  if (reportingLine.managerName) {
+    layers.push({ label: "Manager", value: reportingLine.managerName });
+  }
+  layers.push({ label: "You", value: employee.name });
+  if (reportingLine.directReportNames.length > 0) {
+    layers.push({
+      label: "Reports",
+      value: reportingLine.directReportNames.join(", "),
+    });
+  }
+  return (
+    <View style={styles.section}>
+      <Text style={styles.h2}>Reporting line</Text>
+      {layers.map((row, i) => (
+        <View key={i}>
+          <Text style={styles.reportLine}>
+            <Text style={styles.bold}>{row.label}: </Text>
+            {row.value}
+          </Text>
+          {i < layers.length - 1 && <Text style={styles.arrow}>↓</Text>}
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/apps/platform/src/lib/pdf/components/role-context-section.tsx
+++ b/apps/platform/src/lib/pdf/components/role-context-section.tsx
@@ -1,0 +1,32 @@
+import { View, Text } from "@react-pdf/renderer";
+import { styles } from "../pdf-styles";
+import type { OrgSnapshotData } from "../assemble-org-snapshot";
+
+export function RoleContextSection({ data }: { data: OrgSnapshotData }) {
+  const jd = data.jobDescription;
+  if (!jd) return null;
+  return (
+    <View style={styles.section}>
+      <Text style={styles.h2}>Your role in context</Text>
+      <Text style={styles.paragraph}>{jd.roleSummary}</Text>
+      {jd.coreResponsibilities.length > 0 && (
+        <View style={{ marginTop: 6 }}>
+          <Text style={[styles.paragraph, styles.bold]}>
+            Core responsibilities
+          </Text>
+          {jd.coreResponsibilities.slice(0, 5).map((r, i) => (
+            <Text key={i} style={styles.bullet}>
+              • {r}
+            </Text>
+          ))}
+        </View>
+      )}
+      {jd.competencies.length > 0 && (
+        <View style={{ marginTop: 6 }}>
+          <Text style={[styles.paragraph, styles.bold]}>Competencies</Text>
+          <Text style={styles.paragraph}>{jd.competencies.join(", ")}</Text>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/apps/platform/src/lib/pdf/components/team-map-section.tsx
+++ b/apps/platform/src/lib/pdf/components/team-map-section.tsx
@@ -1,0 +1,21 @@
+import { View, Text } from "@react-pdf/renderer";
+import { styles } from "../pdf-styles";
+import type { OrgSnapshotData } from "../assemble-org-snapshot";
+
+export function TeamMapSection({ data }: { data: OrgSnapshotData }) {
+  if (!data.team.length) return null;
+  return (
+    <View style={styles.section}>
+      <Text style={styles.h2}>Your team in {data.employee.department}</Text>
+      {data.team.map((m) => (
+        <Text
+          key={m.id}
+          style={[styles.bullet, m.isSelf ? styles.bold : {}]}
+        >
+          • {m.name} — {m.jobTitle}
+          {m.isSelf ? " (you)" : ""}
+        </Text>
+      ))}
+    </View>
+  );
+}

--- a/apps/platform/src/lib/pdf/pdf-styles.ts
+++ b/apps/platform/src/lib/pdf/pdf-styles.ts
@@ -1,0 +1,29 @@
+import { StyleSheet } from "@react-pdf/renderer";
+
+export const styles = StyleSheet.create({
+  page: {
+    padding: 40,
+    fontFamily: "Helvetica",
+    fontSize: 11,
+    color: "#0c1e3d",
+  },
+  accentBar: { height: 4, backgroundColor: "#ff6b35", marginBottom: 12 },
+  h1: { fontSize: 22, fontWeight: 700, marginBottom: 6 },
+  h2: {
+    fontSize: 14,
+    fontWeight: 700,
+    marginTop: 16,
+    marginBottom: 4,
+    color: "#0c1e3d",
+  },
+  meta: { fontSize: 9, color: "#64748b" },
+  paragraph: { fontSize: 10, lineHeight: 1.4 },
+  bold: { fontWeight: 700 },
+  bullet: { fontSize: 10, marginLeft: 8, marginBottom: 2 },
+  section: { marginTop: 12 },
+  reportLine: { fontSize: 11, marginBottom: 2 },
+  arrow: { fontSize: 9, color: "#94a3b8", marginLeft: 8, marginBottom: 2 },
+  coverRow: { flexDirection: "row", alignItems: "center" },
+  photo: { width: 64, height: 64, borderRadius: 32, marginRight: 16 },
+  divider: { height: 1, backgroundColor: "#e2e8f0", marginVertical: 10 },
+});

--- a/apps/platform/src/lib/pdf/render-org-snapshot.tsx
+++ b/apps/platform/src/lib/pdf/render-org-snapshot.tsx
@@ -1,0 +1,26 @@
+import { Document, Page, renderToBuffer } from "@react-pdf/renderer";
+import { styles } from "./pdf-styles";
+import type { OrgSnapshotData } from "./assemble-org-snapshot";
+import { CoverSection } from "./components/cover-section";
+import { RoleContextSection } from "./components/role-context-section";
+import { ReportingLineSection } from "./components/reporting-line-section";
+import { TeamMapSection } from "./components/team-map-section";
+import { FocusLayerSectionPdf } from "./components/focus-layer-section-pdf";
+import { MissionAnchorSection } from "./components/mission-anchor-section";
+
+export async function renderOrgSnapshot(
+  data: OrgSnapshotData,
+): Promise<Buffer> {
+  return renderToBuffer(
+    <Document>
+      <Page size="LETTER" style={styles.page}>
+        <CoverSection data={data} />
+        <RoleContextSection data={data} />
+        <ReportingLineSection data={data} />
+        <TeamMapSection data={data} />
+        <FocusLayerSectionPdf data={data} />
+        <MissionAnchorSection data={data} />
+      </Page>
+    </Document>,
+  );
+}

--- a/apps/platform/src/tests/api-organization-pdf.test.ts
+++ b/apps/platform/src/tests/api-organization-pdf.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { connectDB } from "@ascenta/db";
+import { Employee } from "@ascenta/db/employee-schema";
+import { GET } from "@/app/api/employees/[id]/organization-pdf/route";
+
+const SKIP_NO_DB = !process.env.MONGODB_URI;
+
+const PREFIX = "PDF_API_";
+
+async function makeEmp() {
+  return Employee.create({
+    employeeId: `${PREFIX}E1`,
+    firstName: "Pdf",
+    lastName: "User",
+    email: `${PREFIX}p@x.com`,
+    department: "PDF_API_TestDept",
+    jobTitle: "Eng",
+    managerName: "—",
+    hireDate: new Date(),
+  });
+}
+
+function ctx(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe.skipIf(SKIP_NO_DB)("GET /api/employees/[id]/organization-pdf", () => {
+  beforeAll(async () => connectDB());
+  beforeEach(async () => {
+    await Employee.deleteMany({ employeeId: { $regex: `^${PREFIX}` } });
+  });
+  afterAll(async () => {
+    await Employee.deleteMany({ employeeId: { $regex: `^${PREFIX}` } });
+    await mongoose.disconnect();
+  });
+
+  it("returns a PDF binary with correct headers", async () => {
+    const emp = await makeEmp();
+    const res = await GET(
+      new Request("http://t") as never,
+      ctx(String(emp._id)),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/pdf");
+    expect(res.headers.get("content-disposition")).toMatch(/attachment;.*\.pdf/);
+    const buf = Buffer.from(await res.arrayBuffer());
+    expect(buf.subarray(0, 5).toString()).toBe("%PDF-");
+  });
+
+  it("returns 404 for invalid id", async () => {
+    const res = await GET(new Request("http://t") as never, ctx("not-an-id"));
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/platform/src/tests/assemble-org-snapshot.test.ts
+++ b/apps/platform/src/tests/assemble-org-snapshot.test.ts
@@ -91,10 +91,15 @@ async function setup() {
 }
 
 async function cleanup() {
+  const emps = await Employee.find(
+    { employeeId: { $regex: `^${PREFIX}` } },
+    { _id: 1 },
+  ).lean();
+  const empIds = (emps as Array<{ _id: unknown }>).map((e) => e._id);
+  await FocusLayer.deleteMany({ employeeId: { $in: empIds } });
   await Employee.deleteMany({ employeeId: { $regex: `^${PREFIX}` } });
-  await JobDescription.deleteMany({ title: "Software Engineer" });
-  await FocusLayer.deleteMany({});
-  await CompanyFoundation.deleteMany({});
+  await JobDescription.deleteMany({ department: TEST_DEPT });
+  await CompanyFoundation.deleteMany({ values: "Care, Clarity" });
 }
 
 describe.skipIf(SKIP_NO_DB)("assembleOrgSnapshot", () => {

--- a/apps/platform/src/tests/assemble-org-snapshot.test.ts
+++ b/apps/platform/src/tests/assemble-org-snapshot.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import mongoose from "mongoose";
+import { connectDB } from "@ascenta/db";
+import { Employee } from "@ascenta/db/employee-schema";
+import { JobDescription } from "@ascenta/db/job-description-schema";
+import { FocusLayer } from "@ascenta/db/focus-layer-schema";
+import { CompanyFoundation } from "@ascenta/db/foundation-schema";
+import { assembleOrgSnapshot } from "@/lib/pdf/assemble-org-snapshot";
+
+// CI doesn't have MONGODB_URI; skip real-DB integration tests there.
+const SKIP_NO_DB = !process.env.MONGODB_URI;
+
+const PREFIX = "PDF_ASM_";
+const TEST_DEPT = "PDF_ASM_TestDept";
+
+async function setup() {
+  const skip = await Employee.create({
+    employeeId: `${PREFIX}SKIP`,
+    firstName: "Skip",
+    lastName: "Level",
+    email: `${PREFIX}skip@x.com`,
+    department: TEST_DEPT,
+    jobTitle: "VP",
+    managerName: "—",
+    hireDate: new Date(),
+  });
+  const mgr = await Employee.create({
+    employeeId: `${PREFIX}MGR`,
+    firstName: "Manny",
+    lastName: "Manager",
+    email: `${PREFIX}mgr@x.com`,
+    department: TEST_DEPT,
+    jobTitle: "EM",
+    managerName: "Skip Level",
+    hireDate: new Date(),
+  });
+  const jd = await JobDescription.create({
+    title: "Software Engineer",
+    department: TEST_DEPT,
+    level: "mid",
+    employmentType: "full_time",
+    roleSummary: "Builds and maintains software systems for the company.",
+    coreResponsibilities: ["Write code"],
+    requiredQualifications: ["3+ years"],
+    competencies: ["Ownership"],
+    status: "published",
+  });
+  const me = await Employee.create({
+    employeeId: `${PREFIX}ME`,
+    firstName: "Maya",
+    lastName: "Engineer",
+    email: `${PREFIX}me@x.com`,
+    department: TEST_DEPT,
+    jobTitle: "Engineer",
+    managerName: "Manny Manager",
+    hireDate: new Date(),
+    jobDescriptionId: jd._id,
+    profile: { pronouns: "she/her" },
+  });
+  const peer = await Employee.create({
+    employeeId: `${PREFIX}PEER`,
+    firstName: "Pat",
+    lastName: "Peer",
+    email: `${PREFIX}peer@x.com`,
+    department: TEST_DEPT,
+    jobTitle: "Engineer",
+    managerName: "Manny Manager",
+    hireDate: new Date(),
+  });
+  await FocusLayer.create({
+    employeeId: me._id,
+    jobDescriptionId: jd._id,
+    status: "confirmed",
+    responses: {
+      uniqueContribution: "I bring deep cross-team alignment expertise.",
+      highImpactArea: "Most impact when bridging product and engineering.",
+      signatureResponsibility: "I own the architectural narrative.",
+      workingStyle: "Focused 90-min blocks plus async pair sessions.",
+    },
+    employeeSubmitted: { at: new Date() },
+    managerConfirmed: { at: new Date(), byUserId: mgr._id, comment: null },
+  });
+  await CompanyFoundation.create({
+    mission: "Help orgs grow people.",
+    vision: "Every workplace runs on intent.",
+    values: "Care, Clarity",
+    status: "published",
+  });
+  return { skip, mgr, me, peer };
+}
+
+async function cleanup() {
+  await Employee.deleteMany({ employeeId: { $regex: `^${PREFIX}` } });
+  await JobDescription.deleteMany({ title: "Software Engineer" });
+  await FocusLayer.deleteMany({});
+  await CompanyFoundation.deleteMany({});
+}
+
+describe.skipIf(SKIP_NO_DB)("assembleOrgSnapshot", () => {
+  beforeAll(async () => connectDB());
+  beforeEach(async () => cleanup());
+  afterAll(async () => {
+    await cleanup();
+    await mongoose.disconnect();
+  });
+
+  it("builds a full snapshot when all data present", async () => {
+    const { me } = await setup();
+    const snap = await assembleOrgSnapshot(String(me._id));
+    expect(snap.employee.name).toBe("Maya Engineer");
+    expect(snap.employee.pronouns).toBe("she/her");
+    expect(snap.jobDescription?.title).toBe("Software Engineer");
+    expect(snap.reportingLine.managerName).toBe("Manny Manager");
+    expect(snap.reportingLine.skipLevelName).toBe("Skip Level");
+    expect(snap.team.find((m) => m.name === "Pat Peer")).toBeDefined();
+    expect(
+      snap.team.find((m) => m.isSelf && m.name === "Maya Engineer"),
+    ).toBeDefined();
+    expect(snap.focusLayer?.responses.uniqueContribution).toContain(
+      "cross-team",
+    );
+    expect(snap.foundation?.mission).toContain("grow people");
+    expect(snap.foundation?.coreValues).toEqual(["Care", "Clarity"]);
+  });
+
+  it("omits unconfirmed Focus Layers", async () => {
+    const { me } = await setup();
+    await FocusLayer.updateOne(
+      { employeeId: me._id },
+      { $set: { status: "submitted" } },
+    );
+    const snap = await assembleOrgSnapshot(String(me._id));
+    expect(snap.focusLayer).toBeNull();
+  });
+
+  it("omits jobDescription when employee has none assigned", async () => {
+    await setup();
+    const noJd = await Employee.create({
+      employeeId: `${PREFIX}NOJD`,
+      firstName: "No",
+      lastName: "Jd",
+      email: `${PREFIX}nojd@x.com`,
+      department: TEST_DEPT,
+      jobTitle: "Eng",
+      managerName: "Manny Manager",
+      hireDate: new Date(),
+    });
+    const snap = await assembleOrgSnapshot(String(noJd._id));
+    expect(snap.jobDescription).toBeNull();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.3))
+      '@react-pdf/renderer':
+        specifier: ^4.5.1
+        version: 4.5.1(react@19.2.3)
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(next@16.1.4(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
@@ -201,7 +204,7 @@ importers:
         version: 16.1.4(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       jsdom:
         specifier: ^29.0.2
-        version: 29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       tailwindcss:
         specifier: ^4
         version: 4.2.0
@@ -213,7 +216,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.6.1)(jsdom@29.0.2)(lightningcss@1.31.1)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)
 
   packages/config: {}
 
@@ -1067,6 +1070,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1847,6 +1858,49 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-pdf/fns@3.1.3':
+    resolution: {integrity: sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==}
+
+  '@react-pdf/font@4.0.8':
+    resolution: {integrity: sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==}
+
+  '@react-pdf/image@3.1.0':
+    resolution: {integrity: sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==}
+
+  '@react-pdf/layout@4.6.1':
+    resolution: {integrity: sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==}
+
+  '@react-pdf/pdfkit@5.1.1':
+    resolution: {integrity: sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==}
+
+  '@react-pdf/primitives@4.3.0':
+    resolution: {integrity: sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==}
+
+  '@react-pdf/reconciler@2.0.0':
+    resolution: {integrity: sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-pdf/render@4.5.1':
+    resolution: {integrity: sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==}
+
+  '@react-pdf/renderer@4.5.1':
+    resolution: {integrity: sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-pdf/stylesheet@6.2.1':
+    resolution: {integrity: sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==}
+
+  '@react-pdf/svg@1.1.0':
+    resolution: {integrity: sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==}
+
+  '@react-pdf/textkit@6.3.0':
+    resolution: {integrity: sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==}
+
+  '@react-pdf/types@2.11.1':
+    resolution: {integrity: sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==}
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
@@ -2527,6 +2581,9 @@ packages:
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
 
+  abs-svg-path@0.1.1:
+    resolution: {integrity: sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2643,6 +2700,10 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -2667,6 +2728,12 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  brotli@1.3.3:
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
+
+  browserify-zlib@0.2.0:
+    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -2725,6 +2792,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -2741,6 +2812,14 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-name@2.1.0:
+    resolution: {integrity: sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==}
+    engines: {node: '>=12.20'}
+
+  color-string@2.1.4:
+    resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
+    engines: {node: '>=18'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -2974,6 +3053,9 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  dfa@1.2.0:
+    resolution: {integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==}
+
   dingbat-to-unicode@1.0.1:
     resolution: {integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==}
 
@@ -3000,6 +3082,9 @@ packages:
 
   electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
+
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
@@ -3190,6 +3275,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
@@ -3229,6 +3318,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -3247,6 +3339,9 @@ packages:
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  fontkit@2.0.4:
+    resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -3363,6 +3458,12 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hsl-to-hex@1.0.0:
+    resolution: {integrity: sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==}
+
+  hsl-to-rgb-for-reals@1.1.1:
+    resolution: {integrity: sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -3372,6 +3473,9 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  hyphen@1.14.1:
+    resolution: {integrity: sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -3524,6 +3628,9 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -3549,9 +3656,15 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jay-peg@1.1.1:
+    resolution: {integrity: sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-md5@0.8.3:
+    resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3697,6 +3810,9 @@ packages:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
     engines: {node: '>= 12.0.0'}
 
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -3792,6 +3908,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  media-engine@1.0.3:
+    resolution: {integrity: sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==}
 
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
@@ -3988,6 +4107,9 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  normalize-svg-path@1.1.0:
+    resolution: {integrity: sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -4048,6 +4170,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
@@ -4057,6 +4182,9 @@ packages:
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse-svg-path@0.1.2:
+    resolution: {integrity: sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -4099,6 +4227,9 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  png-js@2.0.0:
+    resolution: {integrity: sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -4109,6 +4240,9 @@ packages:
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -4141,6 +4275,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
@@ -4278,6 +4415,9 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restructure@3.0.2:
+    resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -4317,6 +4457,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.25.0-rc-603e6108-20241029:
+    resolution: {integrity: sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4479,6 +4622,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-arc-to-cubic-bezier@3.2.0:
+    resolution: {integrity: sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==}
+
   svix@1.84.1:
     resolution: {integrity: sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==}
 
@@ -4494,6 +4640,9 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4639,6 +4788,12 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  unicode-properties@1.4.1:
+    resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -4706,6 +4861,10 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite-compatible-readable-stream@3.6.1:
+    resolution: {integrity: sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==}
+    engines: {node: '>= 6'}
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -4852,6 +5011,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -5191,7 +5353,9 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.0': {}
+  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
 
   '@floating-ui/core@1.7.4':
     dependencies:
@@ -5425,6 +5589,10 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.1.4':
     optional: true
+
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6242,6 +6410,110 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-pdf/fns@3.1.3': {}
+
+  '@react-pdf/font@4.0.8':
+    dependencies:
+      '@react-pdf/pdfkit': 5.1.1
+      '@react-pdf/types': 2.11.1
+      fontkit: 2.0.4
+      is-url: 1.2.4
+
+  '@react-pdf/image@3.1.0':
+    dependencies:
+      '@react-pdf/svg': 1.1.0
+      jay-peg: 1.1.1
+      png-js: 2.0.0
+
+  '@react-pdf/layout@4.6.1':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/image': 3.1.0
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/stylesheet': 6.2.1
+      '@react-pdf/textkit': 6.3.0
+      '@react-pdf/types': 2.11.1
+      emoji-regex-xs: 1.0.0
+      queue: 6.0.2
+      yoga-layout: 3.2.1
+
+  '@react-pdf/pdfkit@5.1.1':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@noble/ciphers': 1.3.0
+      '@noble/hashes': 1.8.0
+      browserify-zlib: 0.2.0
+      fontkit: 2.0.4
+      jay-peg: 1.1.1
+      js-md5: 0.8.3
+      linebreak: 1.1.0
+      png-js: 2.0.0
+      vite-compatible-readable-stream: 3.6.1
+
+  '@react-pdf/primitives@4.3.0': {}
+
+  '@react-pdf/reconciler@2.0.0(react@19.2.3)':
+    dependencies:
+      object-assign: 4.1.1
+      react: 19.2.3
+      scheduler: 0.25.0-rc-603e6108-20241029
+
+  '@react-pdf/render@4.5.1':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/textkit': 6.3.0
+      '@react-pdf/types': 2.11.1
+      abs-svg-path: 0.1.1
+      color-string: 2.1.4
+      normalize-svg-path: 1.1.0
+      parse-svg-path: 0.1.2
+      svg-arc-to-cubic-bezier: 3.2.0
+
+  '@react-pdf/renderer@4.5.1(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/font': 4.0.8
+      '@react-pdf/layout': 4.6.1
+      '@react-pdf/pdfkit': 5.1.1
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/reconciler': 2.0.0(react@19.2.3)
+      '@react-pdf/render': 4.5.1
+      '@react-pdf/types': 2.11.1
+      events: 3.3.0
+      object-assign: 4.1.1
+      prop-types: 15.8.1
+      queue: 6.0.2
+      react: 19.2.3
+
+  '@react-pdf/stylesheet@6.2.1':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/types': 2.11.1
+      color-string: 2.1.4
+      hsl-to-hex: 1.0.0
+      media-engine: 1.0.3
+      postcss-value-parser: 4.2.0
+
+  '@react-pdf/svg@1.1.0':
+    dependencies:
+      '@react-pdf/primitives': 4.3.0
+
+  '@react-pdf/textkit@6.3.0':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      bidi-js: 1.0.3
+      hyphen: 1.14.1
+      unicode-properties: 1.4.1
+
+  '@react-pdf/types@2.11.1':
+    dependencies:
+      '@react-pdf/font': 4.0.8
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/stylesheet': 6.2.1
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
@@ -6849,6 +7121,8 @@ snapshots:
 
   '@xmldom/xmldom@0.8.11': {}
 
+  abs-svg-path@0.1.1: {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -6985,6 +7259,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@0.0.8: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.0: {}
@@ -7007,6 +7283,14 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
+
+  browserify-zlib@0.2.0:
+    dependencies:
+      pako: 1.0.11
 
   browserslist@4.28.1:
     dependencies:
@@ -7062,6 +7346,8 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  clone@2.1.2: {}
+
   clsx@2.1.1: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
@@ -7081,6 +7367,12 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  color-name@2.1.0: {}
+
+  color-string@2.1.4:
+    dependencies:
+      color-name: 2.1.0
 
   comma-separated-tokens@2.0.3: {}
 
@@ -7263,10 +7555,10 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -7330,6 +7622,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  dfa@1.2.0: {}
+
   dingbat-to-unicode@1.0.1: {}
 
   doctrine@2.1.0:
@@ -7353,6 +7647,8 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.302: {}
+
+  emoji-regex-xs@1.0.0: {}
 
   emoji-regex@9.2.2: {}
 
@@ -7759,6 +8055,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events@3.3.0: {}
+
   eventsource-parser@3.0.6: {}
 
   expect-type@1.3.0: {}
@@ -7789,6 +8087,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fflate@0.8.2: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -7808,6 +8108,18 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.3.3: {}
+
+  fontkit@2.0.4:
+    dependencies:
+      '@swc/helpers': 0.5.15
+      brotli: 1.3.3
+      clone: 2.1.2
+      dfa: 1.2.0
+      fast-deep-equal: 3.1.3
+      restructure: 3.0.2
+      tiny-inflate: 1.0.3
+      unicode-properties: 1.4.1
+      unicode-trie: 2.0.0
 
   for-each@0.3.5:
     dependencies:
@@ -7950,15 +8262,23 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  html-encoding-sniffer@6.0.0:
+  hsl-to-hex@1.0.0:
     dependencies:
-      '@exodus/bytes': 1.15.0
+      hsl-to-rgb-for-reals: 1.1.1
+
+  hsl-to-rgb-for-reals@1.1.1: {}
+
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  hyphen@1.14.1: {}
 
   iconv-lite@0.6.3:
     dependencies:
@@ -8107,6 +8427,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.20
 
+  is-url@1.2.4: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -8133,7 +8455,13 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jay-peg@1.1.1:
+    dependencies:
+      restructure: 3.0.2
+
   jiti@2.6.1: {}
+
+  js-md5@0.8.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -8141,17 +8469,17 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@29.0.2:
+  jsdom@29.0.2(@noble/hashes@1.8.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.3.5
       parse5: 8.0.1
@@ -8162,7 +8490,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -8266,6 +8594,11 @@ snapshots:
       lightningcss-linux-x64-musl: 1.31.1
       lightningcss-win32-arm64-msvc: 1.31.1
       lightningcss-win32-x64-msvc: 1.31.1
+
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
 
   locate-path@6.0.0:
     dependencies:
@@ -8472,6 +8805,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
+
+  media-engine@1.0.3: {}
 
   memory-pager@1.5.0: {}
 
@@ -8766,6 +9101,10 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  normalize-svg-path@1.1.0:
+    dependencies:
+      svg-arc-to-cubic-bezier: 3.2.0
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -8843,6 +9182,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pako@0.2.9: {}
+
   pako@1.0.11: {}
 
   parent-module@1.0.1:
@@ -8858,6 +9199,8 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  parse-svg-path@0.1.2: {}
 
   parse5@8.0.1:
     dependencies:
@@ -8888,6 +9231,10 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  png-js@2.0.0:
+    dependencies:
+      fflate: 0.8.2
+
   possible-typed-array-names@1.1.0: {}
 
   postal-mime@2.7.3: {}
@@ -8896,6 +9243,8 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
     dependencies:
@@ -8930,6 +9279,10 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
 
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -9159,6 +9512,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  restructure@3.0.2: {}
+
   reusify@1.1.0: {}
 
   robust-predicates@3.0.2: {}
@@ -9226,6 +9581,8 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.25.0-rc-603e6108-20241029: {}
 
   scheduler@0.27.0: {}
 
@@ -9452,6 +9809,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-arc-to-cubic-bezier@3.2.0: {}
+
   svix@1.84.1:
     dependencies:
       standardwebhooks: 1.0.0
@@ -9464,6 +9823,8 @@ snapshots:
   tailwindcss@4.2.0: {}
 
   tapable@2.3.0: {}
+
+  tiny-inflate@1.0.3: {}
 
   tinybench@2.9.0: {}
 
@@ -9614,6 +9975,16 @@ snapshots:
 
   undici@7.25.0: {}
 
+  unicode-properties@1.4.1:
+    dependencies:
+      base64-js: 1.5.1
+      unicode-trie: 2.0.0
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -9714,6 +10085,12 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-compatible-readable-stream@3.6.1:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.3
@@ -9729,7 +10106,7 @@ snapshots:
       lightningcss: 1.31.1
       tsx: 4.21.0
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.6.1)(jsdom@29.0.2)(lightningcss@1.31.1)(tsx@4.21.0):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
@@ -9754,7 +10131,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 20.19.33
-      jsdom: 29.0.2
+      jsdom: 29.0.2(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -9783,9 +10160,9 @@ snapshots:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -9852,6 +10229,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yoga-layout@3.2.1: {}
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
## Summary
- Personalized one-page PDF per employee combining role context, reporting line, team, Focus Layer, and Strategy Studio mission
- New `GET /api/employees/[id]/organization-pdf` route streams the binary via `@react-pdf/renderer` (no Chromium); each section gracefully omits when its source data is missing
- "Download My Organization Snapshot" button on the My Profile tab and an icon-only variant on the Employee Profile Card

## Changes
- Adds `@react-pdf/renderer` to `@ascenta/platform`
- `lib/pdf/assemble-org-snapshot.ts` gathers employee, JD, reporting line, same-department team, confirmed Focus Layer, and published `CompanyFoundation` (mission/vision/values parsed into `coreValues`)
- 6 PDF section components + top-level `renderOrgSnapshot` composed onto a single Letter page with Ascenta brand styles (Deep Blue / Summit Orange)
- API route returns 404 for invalid id, 200 with `application/pdf` and `attachment` disposition otherwise; runs on Node runtime
- DB-backed integration tests gated on `MONGODB_URI` (CI-skipped); verifies snapshot assembly and PDF magic-byte response

## Test plan
- [x] `pnpm --filter=@ascenta/platform test` — 184/184 pass
- [x] `pnpm build` — both apps build clean; new dynamic route registered
- [x] `tsc --noEmit` clean
- [x] Live curl smoke: `/api/employees/<id>/organization-pdf` returns valid 1-page PDF (`%PDF-1.3`) for an employee with full data and another missing JD/Focus Layer
- [x] Invalid id returns 404
- [ ] Browser smoke: open Employee Profile dialog → click download icon → PDF downloads
- [ ] Browser smoke: open `/plan/org-design` → My Profile tab → click Download button → PDF downloads

Plan: `docs/superpowers/plans/2026-05-01-my-organization-download.md`
Spec: `docs/superpowers/specs/2026-05-01-my-organization-download-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)